### PR TITLE
chore: Add styled-components plugin to workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "name": "swc-plugins",
   "private": true,
-  "workspaces": ["packages/internal-test", "packages/jest"]
+  "workspaces": ["packages/jest", "packages/styled-components"]
 }


### PR DESCRIPTION
The styled-components plugin is not published to NPM, i guess because it is not defined in the workspaces.