### PR TITLE
feat(emotion): Add emotion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
 name = "better_scoped_tls"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,6 +322,15 @@ dependencies = [
  "proc-macro2",
  "swc_macros_common",
  "syn",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -851,6 +866,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "radix_fmt"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce082a9940a7ace2ad4a8b7d0b1eac6aa378895f18be598230c5f2284ac05426"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1086,7 +1107,7 @@ version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e031f2463ecbdd5f34c950f89f5c1e1032f22c0f8e3dc4bdb2e8b6658cf61eb"
 dependencies = [
- "base64",
+ "base64 0.11.0",
  "if_chain",
  "lazy_static",
  "regex",
@@ -1525,10 +1546,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c0c06b61e1a950c99fab54727f37ef1b3098760fb57a89d9d37ecbdfa103c4"
 dependencies = [
  "swc_ecma_ast",
+ "swc_ecma_codegen",
  "swc_ecma_minifier",
  "swc_ecma_parser",
  "swc_ecma_utils",
  "swc_ecma_visit",
+]
+
+[[package]]
+name = "swc_emotion"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29275c8637ff1e16438d342b9d1ae0d6b4d30fdd3c70bad584c4f014d924d864"
+dependencies = [
+ "base64 0.13.0",
+ "byteorder",
+ "fxhash",
+ "once_cell",
+ "radix_fmt",
+ "regex",
+ "serde",
+ "sourcemap",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecmascript",
 ]
 
 [[package]]
@@ -1568,6 +1609,17 @@ dependencies = [
  "swc_ecma_visit",
  "swc_plugin_macro",
  "swc_plugin_proxy",
+]
+
+[[package]]
+name = "swc_plugin_emotion"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "swc_common",
+ "swc_emotion",
+ "swc_plugin",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+  "packages/emotion",
   "packages/jest",
   "packages/styled-components",
   "packages/styled-jsx",

--- a/packages/emotion/Cargo.toml
+++ b/packages/emotion/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+description = "emotion plugin for https://swc.rs"
+edition = "2021"
+license = "Apache-2.0"
+name = "swc_plugin_emotion"
+version = "0.1.0"
+
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+serde = "*"
+serde_json = "1.0.79"
+swc_common = "0.17.21"
+swc_emotion = "0.3.0"
+swc_plugin = "*"

--- a/packages/emotion/package.json
+++ b/packages/emotion/package.json
@@ -1,0 +1,20 @@
+{
+    "name": "@swc/plugin-emotion",
+    "version": "0.6.0",
+    "description": "SWC plugin for emotion",
+    "main": "swc_plugin_emotion.wasm",
+    "scripts": {
+      "prepack": "cp ../../target/wasm32-wasi/release/swc_plugin_emotion.wasm ."
+    },
+    "homepage": "https://swc.rs",
+    "repository": {
+      "type": "git",
+      "url": "+https://github.com/swc-project/plugins.git"
+    },
+    "bugs": {
+      "url": "https://github.com/swc-project/plugins/issues"
+    },
+    "author": "강동윤 <kdy1997.dev@gmail.com>",
+    "keywords": [],
+    "license": "Apache-2.0"
+  }

--- a/packages/emotion/src/lib.rs
+++ b/packages/emotion/src/lib.rs
@@ -1,0 +1,74 @@
+use serde::Deserialize;
+use std::path::Path;
+use swc_common::{sync::Lrc, SourceMap};
+use swc_emotion::{emotion, EmotionOptions};
+use swc_plugin::{ast::*, plugin_transform, TransformPluginProgramMetadata};
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PluginContext {
+    filename: String,
+    env_name: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "kebab-case")]
+enum EmotionJsAutoLabel {
+    Never,
+    DevOnly,
+    Always,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct EmotionJsOptions {
+    source_map: Option<bool>,
+    auto_label: Option<EmotionJsAutoLabel>,
+    label_format: Option<String>,
+}
+
+// This config transformation has to be the same as https://github.com/vercel/next.js/blob/9fe2f2637c8384ae7939d5a4a30f1557a4262acb/packages/next/build/swc/options.js#L115-L140
+impl EmotionJsOptions {
+    fn to_emotion_options(self, env_name: &str) -> EmotionOptions {
+        EmotionOptions {
+            enabled: Some(true),
+            // sourcemap: Some(self.source_map.unwrap_or(false)),
+            sourcemap: Some(match env_name {
+                "development" => false, /* TODO: use plugin config when sourcemap are supported */
+                // in swc_plugins -> self.source_map.unwrap_or(true),
+                _ => false,
+            }),
+            auto_label: Some(
+                match self.auto_label.unwrap_or(EmotionJsAutoLabel::DevOnly) {
+                    EmotionJsAutoLabel::Always => true,
+                    EmotionJsAutoLabel::Never => false,
+                    EmotionJsAutoLabel::DevOnly => match env_name {
+                        "development" => true,
+                        _ => false,
+                    },
+                },
+            ),
+            label_format: Some(self.label_format.unwrap_or("[local]".to_string())),
+        }
+    }
+}
+
+#[plugin_transform]
+pub fn emotion_plugin(program: Program, data: TransformPluginProgramMetadata) -> Program {
+    let config = serde_json::from_str::<EmotionJsOptions>(&data.plugin_config)
+        .expect("invalid config for emotion");
+
+    let context = serde_json::from_str::<PluginContext>(&data.transform_context)
+        .expect("Invalid plugin context");
+
+    let config = config.to_emotion_options(&context.env_name);
+
+    let path = Path::new(&context.filename);
+    // Sourcemap is wrong at the moment, plugin has to use data.source_map but at
+    // the moment it is not fully supported and cant be converted to
+    // Arc<SourceMap>
+    let cm = Lrc::new(SourceMap::default());
+    let program = program.fold_with(&mut emotion(config, path, cm, data.comments));
+
+    program
+}


### PR DESCRIPTION
- Add emotion plugin from `swc_emotion`

### TODO: Sourcemaps are deactivated right now until are fully supported. https://github.com/swc-project/swc/issues/4282

Plugin can be used right now without sourcemaps (at the moment always use `false`)