### PR TITLE
fix(relay): avoid handler tls crash, allow rootdir config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,9 +1210,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.18.4"
+version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4af6372686d3631234bc555aed9a71f9f89effd37dba8db0ea49942443dd9c13"
+checksum = "269446a3916d32071ca4c1adb39761fd067bc352ba40e40fca11de881ece8007"
 dependencies = [
  "ahash",
  "anyhow",

--- a/packages/jest/Cargo.toml
+++ b/packages/jest/Cargo.toml
@@ -13,6 +13,6 @@ crate-type = ["cdylib", "rlib"]
 phf = {version = "0.10.0", features = ["macros"]}
 serde = {version = "1.0.130", features = ["derive"]}
 swc_atoms = "0.2.11"
-swc_common = { version = "0.18.4", features = ["concurrent"] }
+swc_common = { version = "0.18.5", features = ["concurrent"] }
 swc_ecmascript = { features = ["utils", "visit"], version = "0.157.0" }
 swc_plugin = "0.54.0"

--- a/packages/relay/Cargo.toml
+++ b/packages/relay/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 swc_atoms = "0.2.11"
-swc_common = "0.18.4"
+swc_common = "0.18.5"
 swc_ecmascript = "0.157.0"
 swc_plugin = "0.54.0"
 serde = "1"

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-relay",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "SWC plugin for relay",
   "main": "swc_plugin_relay.wasm",
   "scripts": {

--- a/packages/styled-components/Cargo.toml
+++ b/packages/styled-components/Cargo.toml
@@ -13,5 +13,5 @@ crate-type = ["cdylib", "rlib"]
 serde = {version = "1.0.136", features = ["derive"]}
 serde_json = "1.0.79"
 styled_components = "0.29.0"
-swc_common = "0.18.4"
+swc_common = "0.18.5"
 swc_plugin = "0.54.0"

--- a/packages/styled-jsx/Cargo.toml
+++ b/packages/styled-jsx/Cargo.toml
@@ -11,6 +11,6 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 styled_jsx = "0.4.0"
-swc_common = "0.18.4"
+swc_common = "0.18.5"
 swc_ecmascript = "0.157.0"
 swc_plugin = "0.54.0"


### PR DESCRIPTION
Partially related to https://github.com/swc-project/plugins/issues/35.

PR fixes 2 things

- first, using `swc_common::HANDLER` causes tls access error since it tries to use native host one. use plugin's pseudoscoped key instead.
- secondly, allow to pass `rootDir` instead of manually expand from env::current_dir or /cwd. I was incorrect to expect `PathBuf::from('/cwd')` expands to actual root path. It is not, instead it only gives to fs access to cwd _with mounted virtual path_. We can't use both, instead ask to host passes it.

Closes #35