### PR TITLE
feat(docs): Add light documentation for Relay and Styled Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
-# plugins
-Plugins for swc, written in rust
+# Plugins
+
+Plugins for SWC, written in Rust
+
+#### Currently Available:
+
+- [`emotion`](packages/emotion)
+- [`jest`](packages/jest)
+- [`relay`](packages/relay)
+- [`styled-components`](packages/styled-components)
+- [`styled-jsx`](packages/styled-jsx)
+- [`transform-imports`](packages/transform-imports)

--- a/packages/relay/README.md
+++ b/packages/relay/README.md
@@ -1,0 +1,68 @@
+### `@swc/plugin-relay`
+
+#### Setup
+
+```sh
+npm install --save-dev @swc/plugin-relay @swc/core@1.2.215
+```
+
+> @swc/core@1.2.215 is required for now
+
+### Example
+
+The below shows how to configure `@swc/plugin-relay` and pass the options to Webpack:
+
+Create an `.swcrc.js` file like the below:
+
+```js
+// .swcrc.js
+
+module.exports = {
+  jsc: {
+    experimental: {
+      plugins: [
+        [
+          "@swc/plugin-relay",
+          {
+            language: "typescript",
+            schema: "data/schema.graphql",
+            rootDir: __dirname,
+            src: "src",
+            artifactDirectory: "src/__generated__",
+          },
+        ],
+      ],
+    },
+    parser: {
+      syntax: "typescript",
+      tsx: true,
+    },
+    transform: {
+      react: {
+        runtime: "automatic",
+      },
+    },
+  },
+};
+```
+
+And then update your `swc-loader` Webpack config:
+
+```js
+const swcConfig = require("./.swcrc.js")
+
+// ...
+
+{
+  include: path.resolve("./src"),
+  test: /\.ts$/,
+  use: [
+    {
+      loader: "swc-loader",
+      options: swcConfig,
+    },
+  ],
+}
+```
+
+> Note: We're using a `.swcrc.js` file extension up above and importing the config directly because Relay needs access to `__dirname`, which can't be derived from the default JSON parsed from `.swcrc`.

--- a/packages/styled-components/README.md
+++ b/packages/styled-components/README.md
@@ -1,0 +1,29 @@
+### `@swc/plugin-styled-components`
+
+#### Setup
+
+```sh
+npm install --save-dev @swc/plugin-styled-components @swc/core@1.2.215
+```
+
+> @swc/core@1.2.215 is required for now
+
+Then update your `.swcrc` file like below:
+
+```json
+{
+  "jsc": {
+    "experimental": {
+      "plugins": [
+        [
+          "@swc/plugin-styled-components",
+          {
+            "displayName": true,
+            "ssr": true
+          }
+        ]
+      ]
+    }
+  }
+}
+```


### PR DESCRIPTION
Took me a minute to figure out all of the various pieces of this to [setup in our app](https://github.com/artsy/force/pull/10598) so figured I would come back and add some light docs. 