### PR TITLE
fix(emotion-plugin): change to right plugin name in code example

### DIFF
--- a/packages/emotion/README.md
+++ b/packages/emotion/README.md
@@ -11,7 +11,7 @@ The plugin uses the same config as described in [Next emotion documentation](htt
   jsc: {
     ...
    experimental: {
-     plugins: [ ['emotion-swc-plugin', {
+     plugins: [ ['@swc/plugin-emotion', {
       // default is true. It will be disabled when build type is production.
       sourceMap?: boolean,
       // default is 'dev-only'.


### PR DESCRIPTION
- Fix emotion plugin code example to use the correct name