### PR TITLE
refactor(modularize-imports): Move code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,8 +821,6 @@ dependencies = [
 [[package]]
 name = "modularize_imports"
 version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d00c3a3c643d483d0c528610a897bf1094523e50a67aff60f470142524c906b"
 dependencies = [
  "convert_case",
  "handlebars",
@@ -830,6 +828,7 @@ dependencies = [
  "regex",
  "serde",
  "swc_core",
+ "testing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2122,7 +2122,7 @@ dependencies = [
 
 [[package]]
 name = "swc_emotion"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "base64",
  "byteorder",
@@ -2198,7 +2198,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_emotion"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2243,7 +2243,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_noop"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "swc_common",
  "swc_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1584,7 +1584,7 @@ dependencies = [
 
 [[package]]
 name = "styled_jsx"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "easy-error",
  "swc_core",
@@ -2288,7 +2288,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_styled_jsx"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "easy-error",
  "styled_jsx",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1570,7 +1570,7 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "styled_components"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "Inflector",
  "once_cell",
@@ -2277,7 +2277,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_styled_components"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "modularize_imports"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "convert_case",
  "handlebars",
@@ -2299,7 +2299,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_transform_imports"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "modularize_imports",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2209,7 +2209,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_jest"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "phf",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2219,7 +2219,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_loadable_components"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "once_cell",
  "regex",

--- a/packages/emotion/Cargo.toml
+++ b/packages/emotion/Cargo.toml
@@ -4,7 +4,7 @@ description = "SWC plugin for https://www.npmjs.com/package/babel-plugin-transfo
 edition = "2021"
 license = "Apache-2.0"
 name = "swc_plugin_emotion"
-version = "0.11.0"
+version = "0.12.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -20,4 +20,4 @@ swc_core = { version = "0.40.3", features = [
   "ecma_ast",
   "common",
 ] }
-swc_emotion = {version = "0.27.0", path = "./transform"}
+swc_emotion = {version = "0.28.0", path = "./transform"}

--- a/packages/emotion/package.json
+++ b/packages/emotion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-emotion",
-  "version": "2.5.15",
+  "version": "2.5.16",
   "description": "SWC plugin for emotion css-in-js library",
   "main": "swc_plugin_emotion.wasm",
   "scripts": {

--- a/packages/emotion/transform/Cargo.toml
+++ b/packages/emotion/transform/Cargo.toml
@@ -5,7 +5,7 @@ description = "AST Transforms for emotion"
 license = "Apache-2.0"
 name = "swc_emotion"
 repository = "https://github.com/vercel/next.js.git"
-version = "0.27.0"
+version = "0.28.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/packages/jest/Cargo.toml
+++ b/packages/jest/Cargo.toml
@@ -4,7 +4,7 @@ description = "Jest plugin for https://swc.rs"
 edition = "2018"
 license = "Apache-2.0"
 name = "swc_plugin_jest"
-version = "0.24.0"
+version = "0.25.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-jest",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "description": "SWC plugin for jest",
   "main": "swc_plugin_jest.wasm",
   "scripts": {

--- a/packages/loadable-components/Cargo.toml
+++ b/packages/loadable-components/Cargo.toml
@@ -4,7 +4,7 @@ description = "SWC plugin for `@loadable/components`"
 edition = "2021"
 license = "Apache-2.0"
 name = "swc_plugin_loadable_components"
-version = "0.11.0"
+version = "0.12.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/packages/loadable-components/package.json
+++ b/packages/loadable-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-loadable-components",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "description": "SWC plugin for `@loadable/components`",
   "main": "swc_plugin_loadable_components.wasm",
   "scripts": {

--- a/packages/noop/Cargo.toml
+++ b/packages/noop/Cargo.toml
@@ -4,7 +4,7 @@ description = "Noop plugin for debugging."
 edition = "2018"
 license = "Apache-2.0"
 name = "swc_plugin_noop"
-version = "0.11.0"
+version = "0.12.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/packages/noop/package.json
+++ b/packages/noop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-noop",
-  "version": "1.5.13",
+  "version": "1.5.14",
   "description": "Noop SWC plugin, for debugging",
   "main": "swc_plugin_noop.wasm",
   "scripts": {

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-relay",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "description": "SWC plugin for relay",
   "main": "swc_plugin_relay.wasm",
   "types": "./types.d.ts",

--- a/packages/styled-components/Cargo.toml
+++ b/packages/styled-components/Cargo.toml
@@ -3,7 +3,7 @@ description = "styled-components plugin for https://swc.rs"
 edition = "2018"
 license = "Apache-2.0"
 name = "swc_plugin_styled_components"
-version = "0.33.0"
+version = "0.34.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
@@ -12,7 +12,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 serde = {version = "1.0.136", features = ["derive"]}
 serde_json = "1.0.79"
-styled_components = {version = "0.51.0", path = "./transform"}
+styled_components = {version = "0.52.0", path = "./transform"}
 swc_common = { version = "0.29.10", features = ["concurrent"] }
 swc_core = { version = "0.40.3", features = [
   "plugin_transform",

--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-styled-components",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "description": "SWC plugin for styled-components",
   "main": "swc_plugin_styled_components.wasm",
   "scripts": {

--- a/packages/styled-components/transform/Cargo.toml
+++ b/packages/styled-components/transform/Cargo.toml
@@ -6,7 +6,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 license = "Apache-2.0"
 name = "styled_components"
 repository = "https://github.com/vercel/next.js.git"
-version = "0.51.0"
+version = "0.52.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/packages/styled-jsx/Cargo.toml
+++ b/packages/styled-jsx/Cargo.toml
@@ -4,7 +4,7 @@ description = "SWC Plugin for styled-jsx"
 edition = "2021"
 license = "Apache-2.0"
 name = "swc_plugin_styled_jsx"
-version = "0.13.0"
+version = "0.14.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -30,7 +30,7 @@ swc_core = { version = "0.40.3", features = [
   "ecma_visit",
 ] }
 
-styled_jsx = {version = "0.28.0", path = "./transform"}
+styled_jsx = {version = "0.29.0", path = "./transform"}
 
 [dev-dependencies]
 swc_core = { features = [

--- a/packages/styled-jsx/package.json
+++ b/packages/styled-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-styled-jsx",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "description": "SWC plugin for styled-jsx",
   "main": "swc_plugin_styled_jsx.wasm",
   "scripts": {

--- a/packages/styled-jsx/transform/Cargo.toml
+++ b/packages/styled-jsx/transform/Cargo.toml
@@ -4,7 +4,7 @@ description = "AST transforms visitor for styled-jsx"
 edition = "2021"
 license = "Apache-2.0"
 name = "styled_jsx"
-version = "0.28.0"
+version = "0.29.0"
 
 [features]
 custom_transform = ["swc_core/common_concurrent"]

--- a/packages/transform-imports/Cargo.toml
+++ b/packages/transform-imports/Cargo.toml
@@ -12,11 +12,11 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 modularize_imports = {version = "0.24.0", path = "./transform"}
 serde_json = "1.0.79"
-swc_common = {version = "0.29.10", features = ["concurrent"]}
-swc_core = {version = "0.40.3", features = [
+swc_common = { version = "0.29.10", features = ["concurrent"] }
+swc_core = { version = "0.40.3", features = [
   "plugin_transform",
   "ecma_utils",
   "ecma_visit",
   "ecma_ast",
   "common",
-]}
+] }

--- a/packages/transform-imports/Cargo.toml
+++ b/packages/transform-imports/Cargo.toml
@@ -10,13 +10,13 @@ version = "0.12.0"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-modularize_imports = "0.24.0"
+modularize_imports = {version = "0.24.0", path = "./transform"}
 serde_json = "1.0.79"
-swc_common = { version = "0.29.10", features = ["concurrent"] }
-swc_core = { version = "0.40.3", features = [
+swc_common = {version = "0.29.10", features = ["concurrent"]}
+swc_core = {version = "0.40.3", features = [
   "plugin_transform",
   "ecma_utils",
   "ecma_visit",
   "ecma_ast",
   "common",
-] }
+]}

--- a/packages/transform-imports/Cargo.toml
+++ b/packages/transform-imports/Cargo.toml
@@ -4,13 +4,13 @@ description = "SWC plugin for https://www.npmjs.com/package/babel-plugin-transfo
 edition = "2021"
 license = "Apache-2.0"
 name = "swc_plugin_transform_imports"
-version = "0.12.0"
+version = "0.13.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-modularize_imports = {version = "0.24.0", path = "./transform"}
+modularize_imports = {version = "0.25.0", path = "./transform"}
 serde_json = "1.0.79"
 swc_common = { version = "0.29.10", features = ["concurrent"] }
 swc_core = { version = "0.40.3", features = [

--- a/packages/transform-imports/package.json
+++ b/packages/transform-imports/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-transform-imports",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "description": "SWC plugin for https://www.npmjs.com/package/babel-plugin-transform-imports",
   "main": "swc_plugin_transform_imports.wasm",
   "scripts": {

--- a/packages/transform-imports/transform/Cargo.toml
+++ b/packages/transform-imports/transform/Cargo.toml
@@ -15,8 +15,8 @@ handlebars = "4.2.1"
 once_cell = "1.13.0"
 regex = "1.5"
 serde = "1"
-swc_core = { features = ["cached", "ecma_ast", "ecma_visit"], version = "0.40.1" }
+swc_core = { features = ["cached", "ecma_ast", "ecma_visit"], version = "0.40.3" }
 
 [dev-dependencies]
-swc_core = { features = ["testing_transform"], version = "0.40.1" }
+swc_core = { features = ["testing_transform"], version = "0.40.3" }
 testing = "0.31.10"

--- a/packages/transform-imports/transform/Cargo.toml
+++ b/packages/transform-imports/transform/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+authors = ["강동윤 <kdy1997.dev@gmail.com>"]
+description = "AST Transforms for import modularizer"
+edition = "2018"
+license = "Apache-2.0"
+name = "modularize_imports"
+repository = "https://github.com/vercel/next.js.git"
+version = "0.24.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+convert_case = "0.5.0"
+handlebars = "4.2.1"
+once_cell = "1.13.0"
+regex = "1.5"
+serde = "1"
+swc_core = { features = ["cached", "ecma_ast", "ecma_visit"], version = "0.40.1" }
+
+[dev-dependencies]
+swc_core = { features = ["testing_transform"], version = "0.40.1" }
+testing = "0.31.10"

--- a/packages/transform-imports/transform/Cargo.toml
+++ b/packages/transform-imports/transform/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 license = "Apache-2.0"
 name = "modularize_imports"
 repository = "https://github.com/vercel/next.js.git"
-version = "0.24.0"
+version = "0.25.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/packages/transform-imports/transform/src/lib.rs
+++ b/packages/transform-imports/transform/src/lib.rs
@@ -1,0 +1,249 @@
+use std::collections::HashMap;
+
+use convert_case::{Case, Casing};
+use handlebars::{Context, Handlebars, Helper, HelperResult, Output, RenderContext};
+use once_cell::sync::Lazy;
+use regex::{Captures, Regex};
+use serde::{Deserialize, Serialize};
+
+use swc_core::{
+    cached::regex::CachedRegex,
+    ecma::ast::*,
+    ecma::visit::{noop_fold_type, Fold},
+};
+
+static DUP_SLASH_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"//").unwrap());
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(transparent)]
+pub struct Config {
+    pub packages: HashMap<String, PackageConfig>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PackageConfig {
+    pub transform: String,
+    #[serde(default)]
+    pub prevent_full_import: bool,
+    #[serde(default)]
+    pub skip_default_conversion: bool,
+}
+
+struct FoldImports {
+    renderer: handlebars::Handlebars<'static>,
+    packages: Vec<(CachedRegex, PackageConfig)>,
+}
+
+struct Rewriter<'a> {
+    renderer: &'a handlebars::Handlebars<'static>,
+    key: &'a str,
+    config: &'a PackageConfig,
+    group: Vec<&'a str>,
+}
+
+impl<'a> Rewriter<'a> {
+    fn rewrite(&self, old_decl: &ImportDecl) -> Vec<ImportDecl> {
+        if old_decl.type_only || old_decl.asserts.is_some() {
+            return vec![old_decl.clone()];
+        }
+
+        let mut out: Vec<ImportDecl> = Vec::with_capacity(old_decl.specifiers.len());
+
+        for spec in &old_decl.specifiers {
+            match spec {
+                ImportSpecifier::Named(named_spec) => {
+                    #[derive(Serialize)]
+                    #[serde(untagged)]
+                    enum Data<'a> {
+                        Plain(&'a str),
+                        Array(&'a [&'a str]),
+                    }
+                    let mut ctx: HashMap<&str, Data> = HashMap::new();
+                    ctx.insert("matches", Data::Array(&self.group[..]));
+                    ctx.insert(
+                        "member",
+                        Data::Plain(
+                            named_spec
+                                .imported
+                                .as_ref()
+                                .map(|x| match x {
+                                    ModuleExportName::Ident(x) => x.as_ref(),
+                                    ModuleExportName::Str(x) => x.value.as_ref(),
+                                })
+                                .unwrap_or_else(|| named_spec.local.as_ref()),
+                        ),
+                    );
+                    let new_path = self
+                        .renderer
+                        .render_template(&self.config.transform, &ctx)
+                        .unwrap_or_else(|e| {
+                            panic!("error rendering template for '{}': {}", self.key, e);
+                        });
+                    let new_path = DUP_SLASH_REGEX.replace_all(&new_path, |_: &Captures| "/");
+                    let specifier = if self.config.skip_default_conversion {
+                        ImportSpecifier::Named(named_spec.clone())
+                    } else {
+                        ImportSpecifier::Default(ImportDefaultSpecifier {
+                            local: named_spec.local.clone(),
+                            span: named_spec.span,
+                        })
+                    };
+                    out.push(ImportDecl {
+                        specifiers: vec![specifier],
+                        src: Box::new(Str::from(new_path.as_ref())),
+                        span: old_decl.span,
+                        type_only: false,
+                        asserts: None,
+                    });
+                }
+                _ => {
+                    if self.config.prevent_full_import {
+                        panic!(
+                            "import {:?} causes the entire module to be imported",
+                            old_decl
+                        );
+                    } else {
+                        // Give up
+                        return vec![old_decl.clone()];
+                    }
+                }
+            }
+        }
+        out
+    }
+}
+
+impl FoldImports {
+    fn should_rewrite<'a>(&'a self, name: &'a str) -> Option<Rewriter<'a>> {
+        for (regex, config) in &self.packages {
+            let group = regex.captures(name);
+            if let Some(group) = group {
+                let group = group
+                    .iter()
+                    .map(|x| x.map(|x| x.as_str()).unwrap_or_default())
+                    .collect::<Vec<&str>>();
+                return Some(Rewriter {
+                    renderer: &self.renderer,
+                    key: name,
+                    config,
+                    group,
+                });
+            }
+        }
+        None
+    }
+}
+
+impl Fold for FoldImports {
+    noop_fold_type!();
+    fn fold_module(&mut self, mut module: Module) -> Module {
+        let mut new_items: Vec<ModuleItem> = vec![];
+        for item in module.body {
+            match item {
+                ModuleItem::ModuleDecl(ModuleDecl::Import(decl)) => {
+                    match self.should_rewrite(&decl.src.value) {
+                        Some(rewriter) => {
+                            let rewritten = rewriter.rewrite(&decl);
+                            new_items.extend(
+                                rewritten
+                                    .into_iter()
+                                    .map(|x| ModuleItem::ModuleDecl(ModuleDecl::Import(x))),
+                            );
+                        }
+                        None => new_items.push(ModuleItem::ModuleDecl(ModuleDecl::Import(decl))),
+                    }
+                }
+                x => {
+                    new_items.push(x);
+                }
+            }
+        }
+        module.body = new_items;
+        module
+    }
+}
+
+pub fn modularize_imports(config: Config) -> impl Fold {
+    let mut folder = FoldImports {
+        renderer: handlebars::Handlebars::new(),
+        packages: vec![],
+    };
+    folder
+        .renderer
+        .register_helper("lowerCase", Box::new(helper_lower_case));
+    folder
+        .renderer
+        .register_helper("upperCase", Box::new(helper_upper_case));
+    folder
+        .renderer
+        .register_helper("camelCase", Box::new(helper_camel_case));
+    folder
+        .renderer
+        .register_helper("kebabCase", Box::new(helper_kebab_case));
+    for (mut k, v) in config.packages {
+        // XXX: Should we keep this hack?
+        if !k.starts_with('^') && !k.ends_with('$') {
+            k = format!("^{}$", k);
+        }
+        folder.packages.push((
+            CachedRegex::new(&k).expect("transform-imports: invalid regex"),
+            v,
+        ));
+    }
+    folder
+}
+
+fn helper_lower_case(
+    h: &Helper<'_, '_>,
+    _: &Handlebars<'_>,
+    _: &Context,
+    _: &mut RenderContext<'_, '_>,
+    out: &mut dyn Output,
+) -> HelperResult {
+    // get parameter from helper or throw an error
+    let param = h.param(0).and_then(|v| v.value().as_str()).unwrap_or("");
+    out.write(param.to_lowercase().as_ref())?;
+    Ok(())
+}
+
+fn helper_upper_case(
+    h: &Helper<'_, '_>,
+    _: &Handlebars<'_>,
+    _: &Context,
+    _: &mut RenderContext<'_, '_>,
+    out: &mut dyn Output,
+) -> HelperResult {
+    // get parameter from helper or throw an error
+    let param = h.param(0).and_then(|v| v.value().as_str()).unwrap_or("");
+    out.write(param.to_uppercase().as_ref())?;
+    Ok(())
+}
+
+fn helper_camel_case(
+    h: &Helper<'_, '_>,
+    _: &Handlebars<'_>,
+    _: &Context,
+    _: &mut RenderContext<'_, '_>,
+    out: &mut dyn Output,
+) -> HelperResult {
+    // get parameter from helper or throw an error
+    let param = h.param(0).and_then(|v| v.value().as_str()).unwrap_or("");
+
+    out.write(param.to_case(Case::Camel).as_ref())?;
+    Ok(())
+}
+
+fn helper_kebab_case(
+    h: &Helper<'_, '_>,
+    _: &Handlebars<'_>,
+    _: &Context,
+    _: &mut RenderContext<'_, '_>,
+    out: &mut dyn Output,
+) -> HelperResult {
+    // get parameter from helper or throw an error
+    let param = h.param(0).and_then(|v| v.value().as_str()).unwrap_or("");
+
+    out.write(param.to_case(Case::Kebab).as_ref())?;
+    Ok(())
+}

--- a/packages/transform-imports/transform/tests/fixture.rs
+++ b/packages/transform-imports/transform/tests/fixture.rs
@@ -1,0 +1,68 @@
+use std::path::PathBuf;
+
+use modularize_imports::{modularize_imports, PackageConfig};
+use swc_core::{
+    ecma::parser::{EsConfig, Syntax},
+    ecma::transforms::testing::{test_fixture, FixtureTestConfig},
+};
+use testing::fixture;
+
+fn syntax() -> Syntax {
+    Syntax::Es(EsConfig {
+        jsx: true,
+        ..Default::default()
+    })
+}
+
+#[fixture("tests/fixture/**/input.js")]
+fn modularize_imports_fixture(input: PathBuf) {
+    let output = input.parent().unwrap().join("output.js");
+    test_fixture(
+        syntax(),
+        &|_tr| {
+            modularize_imports(modularize_imports::Config {
+                packages: vec![
+                    (
+                        "react-bootstrap".to_string(),
+                        PackageConfig {
+                            transform: "react-bootstrap/lib/{{member}}".into(),
+                            prevent_full_import: false,
+                            skip_default_conversion: false,
+                        },
+                    ),
+                    (
+                        "my-library/?(((\\w*)?/?)*)".to_string(),
+                        PackageConfig {
+                            transform: "my-library/{{ matches.[1] }}/{{member}}".into(),
+                            prevent_full_import: false,
+                            skip_default_conversion: false,
+                        },
+                    ),
+                    (
+                        "my-library-2".to_string(),
+                        PackageConfig {
+                            transform: "my-library-2/{{ camelCase member }}".into(),
+                            prevent_full_import: false,
+                            skip_default_conversion: true,
+                        },
+                    ),
+                    (
+                        "my-library-3".to_string(),
+                        PackageConfig {
+                            transform: "my-library-3/{{ kebabCase member }}".into(),
+                            prevent_full_import: false,
+                            skip_default_conversion: true,
+                        },
+                    ),
+                ]
+                .into_iter()
+                .collect(),
+            })
+        },
+        &input,
+        &output,
+        FixtureTestConfig {
+            ..Default::default()
+        },
+    );
+}

--- a/packages/transform-imports/transform/tests/fixture/regex/input.js
+++ b/packages/transform-imports/transform/tests/fixture/regex/input.js
@@ -1,0 +1,3 @@
+import { MyModule } from 'my-library';
+import { App } from 'my-library/components';
+import { Header, Footer } from 'my-library/components/App';

--- a/packages/transform-imports/transform/tests/fixture/regex/output.js
+++ b/packages/transform-imports/transform/tests/fixture/regex/output.js
@@ -1,0 +1,4 @@
+import MyModule from "my-library/MyModule";
+import App from "my-library/components/App";
+import Header from "my-library/components/App/Header";
+import Footer from "my-library/components/App/Footer";

--- a/packages/transform-imports/transform/tests/fixture/simple/input.js
+++ b/packages/transform-imports/transform/tests/fixture/simple/input.js
@@ -1,0 +1,3 @@
+import { Grid, Row, Col as Col1 } from 'react-bootstrap';
+import { MyModule, Widget } from 'my-library-2';
+import { MyModule } from 'my-library-3';

--- a/packages/transform-imports/transform/tests/fixture/simple/output.js
+++ b/packages/transform-imports/transform/tests/fixture/simple/output.js
@@ -1,0 +1,6 @@
+import Grid from "react-bootstrap/lib/Grid";
+import Row from "react-bootstrap/lib/Row";
+import Col1 from "react-bootstrap/lib/Col";
+import { MyModule } from "my-library-2/myModule";
+import { Widget } from "my-library-2/widget";
+import { MyModule } from "my-library-3/my-module";


### PR DESCRIPTION
We are planning to move code to this repository to make maintenance easier.
But the license is a bit different - swc plugins are licensed under Apache 2.0 and have CLA (although I don't care about it.. I configured it just to avoid process like this)

So I'm asking the external contributors if they agree with moving the code.

Please leave a comment with `I agree` if you agree with these changes


---

cc

 - [x] @losfair for https://github.com/vercel/next.js/commit/860c97ccf597eddec9422cab06ab8a7cc328d8bb
 - [x] @nnnnoel for https://github.com/vercel/next.js/commit/40f0eb126ba08dd821f8e7ce95dc61bd1eac2fc0

