### PR TITLE
build(cargo): bump up swc_core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1613,9 +1613,9 @@ dependencies = [
 
 [[package]]
 name = "swc_atoms"
-version = "0.4.25"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b8033a868fbebf5829797ac0c543499622b657e2d33a08ca6ab12547b8bafc"
+checksum = "cef7796df1985447f1fb8803ca2a00b445b20abbc65c8e73acb08835d7651ff0"
 dependencies = [
  "once_cell",
  "rkyv",
@@ -1642,9 +1642,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.29.19"
+version = "0.29.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e2328ba5e7c8f83ff8273b352c890f981d80d215ee29cddcbe19aa789d3592"
+checksum = "811faf77280a5f43fedf06769c391d4f2ed274b1ce9267e3a47e9b13527930b7"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1700,9 +1700,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.47.0"
+version = "0.48.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5adb022589d08fd20f4db232f18c10a6ccb0e3e8a9599b51b7821a7d8164d705"
+checksum = "7354f4e3070914ba114aac0a28fc7afa3ee135f4ed2ddc5a04c6e93d511a75d5"
 dependencies = [
  "once_cell",
  "swc_atoms",
@@ -1732,9 +1732,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_ast"
-version = "0.130.0"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87d1c0282d05d9c82b434e949e7fc7bde340c6680cf7982bb23ec5cdc7eb2aa4"
+checksum = "894fb6d6c166de1791ffe55d1ac109ad668cf3abc1f93161f99f938afd02c139"
 dependencies = [
  "is-macro",
  "serde",
@@ -1745,9 +1745,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_codegen"
-version = "0.140.0"
+version = "0.141.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bc5e13d5c9d0ba85e66e836b3c64f823e92a84bcd83fb6425cecf654dbeccd9"
+checksum = "5b1d69f26cc8da2753c18512b5d7399802d2d89540bed73e0f22d74e3ecd3768"
 dependencies = [
  "auto_impl",
  "bitflags",
@@ -1775,9 +1775,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_parser"
-version = "0.139.0"
+version = "0.140.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9d0735d294350e4fced9f61e6743001c3e844e110913ac3e3027a1390ff5b61"
+checksum = "562eb4abd0418fe4f88e3d89d50165b6474a0b8de23223dddea5d0a070f95c37"
 dependencies = [
  "bitflags",
  "lexical",
@@ -1789,9 +1789,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_prefixer"
-version = "0.141.0"
+version = "0.142.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2922f05de196d8baec2fc7c8ed853fe3991cc96053ea4ccffc8c775bbf77d30e"
+checksum = "b5ff247f53edcaacae0e636493841613f44f360dbd0a539206c08608d4295667"
 dependencies = [
  "once_cell",
  "preset_env_base",
@@ -1806,9 +1806,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_utils"
-version = "0.127.0"
+version = "0.128.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffcf71f1038355f46bbc7cabe9db9e7828f64de337a9e481eb78647a4234305f"
+checksum = "ca6ff8ec9406f49a26a7902af695b5be84a25c4d42ef5b1808734fd0bfb60be1"
 dependencies = [
  "once_cell",
  "serde",
@@ -1821,9 +1821,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_visit"
-version = "0.129.0"
+version = "0.130.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375dccc064ef26b1ca99ebbbd520c0036bf850f189e904ad4c7d3a823289cf1d"
+checksum = "8d11cea17eec9822b62319e7fe71d545e8410519d0953605e7d33dcea2e1adcd"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -1834,9 +1834,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.95.3"
+version = "0.95.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420947496193d5d7f47999ea2d438a3a41e1042393520e28dfb978655f5cacc8"
+checksum = "724a26e6f2c9fdbeee174ebfd9941c52ed13169b59afa2b056d45a731af10dc1"
 dependencies = [
  "bitflags",
  "is-macro",
@@ -1852,9 +1852,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.128.5"
+version = "0.128.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f63f42f1df360e1228867bfe2cfaeec098b8ba44cc48b122b9eb47041804318"
+checksum = "348c51cf036d7ad25ac4a920d0583f7566a5c3da10e16c18b59ef85b781f61c7"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -1884,9 +1884,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.160.10"
+version = "0.160.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "365cde2ba6f0fbdf5ad0d4bb298d86f944d5832ae24c2170338bd98308a722c3"
+checksum = "2dea5ed4ee189e32855138d2992e56d6b5438441fc3c67a01f6a2bdd08338c60"
 dependencies = [
  "ahash",
  "arrayvec",
@@ -1919,9 +1919,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.123.5"
+version = "0.123.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36e1f25619baa61f14bf19fcdf71b2608ff8e1ddfc3049c568d77be156db147d"
+checksum = "3586174b43914a9c0d036a3bb1a63f801e3fe00ee5e8cf8a2575c6a925103436"
 dependencies = [
  "either",
  "enum_kind",
@@ -1938,9 +1938,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_quote_macros"
-version = "0.34.5"
+version = "0.34.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81d5d4d2e0f592011f6ee75775995e4605aec31d518bfb2f52619f75e25a637b"
+checksum = "cb6016e105ce3bd0d78b64cc733b57fa1c51176de463b3791bca1eb9be89e57d"
 dependencies = [
  "anyhow",
  "pmutil",
@@ -1968,9 +1968,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.112.6"
+version = "0.112.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc5fa4c98c86fffcb728f4ae159ebf20d406d6fbfc398a8249e74f51b04f815"
+checksum = "926218b047afb30fd47af74ccde0679173312daa2ed9914c2387593b936184e5"
 dependencies = [
  "better_scoped_tls",
  "bitflags",
@@ -2003,9 +2003,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.168.8"
+version = "0.168.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2772277d118416d069cb8482aa343eb11f1fe2c4e2a28be6e006adb85cf3ec"
+checksum = "71eac570232af14053345022d001821e5892bbea0134a356d7b75734fcc7041f"
 dependencies = [
  "ahash",
  "dashmap",
@@ -2028,9 +2028,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.156.7"
+version = "0.156.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36bf0c2bb721fab85a741d2cf724d0f4aa97e6c144019ed46e04cf13a9792cca"
+checksum = "cd37419dc9048287bc4fce61e57b64ffbfa6147705a53ab833e7ad842d4d5389"
 dependencies = [
  "ahash",
  "base64",
@@ -2054,9 +2054,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.115.7"
+version = "0.115.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0afb1c49a8ab9692ece806d0b984ba7476e3042486fb021ff2f63a67fc9094aa"
+checksum = "c0fea979f0d9fd15411de026739c28b1166f164213cb4d9dac07a25c59b49354"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -2080,9 +2080,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_usage_analyzer"
-version = "0.1.0"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f25f82674e4eb0d47c22b571b256fe536be53caee5a3f94179261ecfe4ed7e19"
+checksum = "c5a35fd4a9060a918f2afd3c7574e2459d150633ba858bf01e335e6e18e41ce1"
 dependencies = [
  "ahash",
  "indexmap",
@@ -2098,9 +2098,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.106.5"
+version = "0.106.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d350bea15d0c71c36a65af37217b32f2675e9d88cd484c11e48beaf9dd2057a"
+checksum = "658ccfb3b72ab6646df4f1d389b9df1310be76d12d1b2625fd8748163773bf4e"
 dependencies = [
  "indexmap",
  "num_cpus",
@@ -2115,9 +2115,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.81.3"
+version = "0.81.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e4b92aa87251452508165d5e86100d35454857cd0c985a9a3bed3dd15a2eb24"
+checksum = "6fa0f5e65af0764045ef268c19d8e0f7fed27ff95c69c198427dcfd5b10685a8"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -2159,9 +2159,9 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "0.13.20"
+version = "0.13.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b8dba54343538503f4e8f8110b569dcf2ac0781b0afd7a950fdc97814f14a4c"
+checksum = "035712357b19deefa23cec538f5cca48e6a799b1f37f6bf7cfbf1328f035c030"
 dependencies = [
  "anyhow",
  "miette",
@@ -2172,9 +2172,9 @@ dependencies = [
 
 [[package]]
 name = "swc_fast_graph"
-version = "0.17.20"
+version = "0.17.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42fcf78c0d5bf767a862a125184b9e3e53dfd44a78e17df1a08eefe030712cae"
+checksum = "e69603ddc8607e2ea0b8482f868c6b0f30269e790c6cea227b9ae288a35f7d04"
 dependencies = [
  "ahash",
  "indexmap",
@@ -2261,9 +2261,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "0.23.3"
+version = "0.23.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3e86675e04908eb81ba42376166cb3bf9360b2f11b26d33ebd165f5d62a5d89"
+checksum = "dc201c805d2a36b216decc718d538c176aec96c917a513c28874e3de07070958"
 dependencies = [
  "better_scoped_tls",
  "rkyv",
@@ -2326,9 +2326,9 @@ version = "0.1.8"
 
 [[package]]
 name = "swc_timer"
-version = "0.17.20"
+version = "0.17.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c76685d10cf9f94f69b193729830dc2e8cc8e840daa1f9bd2aada773ea6064e"
+checksum = "6dc515fc35ddbf9a63a92b8310b50f9970f2215e1e4d2ca5dc7857a11355f98d"
 dependencies = [
  "tracing",
 ]
@@ -2414,9 +2414,9 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "0.31.20"
+version = "0.31.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b96c1192fef3c7f6c7962e5861c3c90982ee0cfba5a5fbb1c666ab8df4b495e"
+checksum = "81be4c3a0e1150b5cfe1f7381a3ea608bfc56a22f54469d8b6a663cd1cad52a1"
 dependencies = [
  "ansi_term",
  "difference",

--- a/packages/emotion/Cargo.toml
+++ b/packages/emotion/Cargo.toml
@@ -13,8 +13,8 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 serde = "1"
 serde_json = "1.0.79"
-swc_common = { version = "0.29.19", features = ["concurrent"] }
-swc_core = { version = "0.47.0", features = [
+swc_common = { version = "0.29.23", features = ["concurrent"] }
+swc_core = { version = "0.48.12", features = [
   "ecma_plugin_transform",
   "ecma_utils",
   "ecma_visit",

--- a/packages/emotion/transform/Cargo.toml
+++ b/packages/emotion/transform/Cargo.toml
@@ -25,7 +25,7 @@ swc_core = { features = [
   "ecma_utils",
   "ecma_visit",
   "trace_macro",
-], version = "0.47.0" }
+], version = "0.48.12" }
 tracing = {version = "0.1.37", features = ["release_max_level_info"]}
 
 [dev-dependencies]
@@ -33,5 +33,5 @@ serde_json = "1"
 swc_core = { features = [
   "testing_transform",
   "ecma_transforms_react",
-], version = "0.47.0" }
-testing = "0.31.20"
+], version = "0.48.12" }
+testing = "0.31.24"

--- a/packages/jest/Cargo.toml
+++ b/packages/jest/Cargo.toml
@@ -13,8 +13,8 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 phf = { version = "0.10.0", features = ["macros"] }
 serde = { version = "1.0.130", features = ["derive"] }
-swc_common = { version = "0.29.19", features = ["concurrent"] }
-swc_core = { version = "0.47.0", features = [
+swc_common = { version = "0.29.23", features = ["concurrent"] }
+swc_core = { version = "0.48.12", features = [
   "ecma_plugin_transform",
   "ecma_utils",
   "ecma_visit",

--- a/packages/loadable-components/Cargo.toml
+++ b/packages/loadable-components/Cargo.toml
@@ -14,8 +14,8 @@ crate-type = ["cdylib", "rlib"]
 once_cell = "1.13.1"
 regex = "1.6.0"
 serde_json = "1.0.79"
-swc_common = { version = "0.29.19", features = ["concurrent"] }
-swc_core = { version = "0.47.0", features = [
+swc_common = { version = "0.29.23", features = ["concurrent"] }
+swc_core = { version = "0.48.12", features = [
   "ecma_plugin_transform",
   "ecma_utils",
   "ecma_visit",
@@ -26,4 +26,4 @@ swc_core = { version = "0.47.0", features = [
 tracing = { version = "0.1.37", features = ["release_max_level_off"] }
 
 [dev-dependencies]
-testing = "0.31.20"
+testing = "0.31.24"

--- a/packages/noop/Cargo.toml
+++ b/packages/noop/Cargo.toml
@@ -11,8 +11,8 @@ version = "0.12.3"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-swc_common = { version = "0.29.19", features = ["concurrent"] }
-swc_core = { version = "0.47.0", features = [
+swc_common = { version = "0.29.23", features = ["concurrent"] }
+swc_core = { version = "0.48.12", features = [
   "ecma_plugin_transform",
   "ecma_utils",
   "ecma_visit",

--- a/packages/relay/Cargo.toml
+++ b/packages/relay/Cargo.toml
@@ -15,8 +15,8 @@ once_cell = "1.8.0"
 regex = "1.5"
 serde = "1"
 serde_json = "1"
-swc_common = { version = "0.29.19", features = ["concurrent"] }
-swc_core = { version = "0.47.0", features = [
+swc_common = { version = "0.29.23", features = ["concurrent"] }
+swc_core = { version = "0.48.12", features = [
   "ecma_plugin_transform",
   "ecma_utils",
   "ecma_visit",

--- a/packages/styled-components/Cargo.toml
+++ b/packages/styled-components/Cargo.toml
@@ -14,8 +14,8 @@ crate-type = ["cdylib", "rlib"]
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 styled_components = { version = "0.52.0", path = "./transform" }
-swc_common = { version = "0.29.19", features = ["concurrent"] }
-swc_core = { version = "0.47.0", features = [
+swc_common = { version = "0.29.23", features = ["concurrent"] }
+swc_core = { version = "0.48.12", features = [
   "ecma_plugin_transform",
   "ecma_utils",
   "ecma_visit",

--- a/packages/styled-components/transform/Cargo.toml
+++ b/packages/styled-components/transform/Cargo.toml
@@ -23,7 +23,7 @@ swc_core = { features = [
   "ecma_ast",
   "ecma_utils",
   "ecma_visit",
-], version = "0.47.0" }
+], version = "0.48.12" }
 tracing = "0.1.37"
 
 [dev-dependencies]
@@ -32,5 +32,5 @@ swc_core = { features = [
   "ecma_parser",
   "ecma_transforms",
   "testing_transform",
-], version = "0.47.0" }
-testing = "0.31.20"
+], version = "0.48.12" }
+testing = "0.31.24"

--- a/packages/styled-jsx/Cargo.toml
+++ b/packages/styled-jsx/Cargo.toml
@@ -16,7 +16,7 @@ custom_transform = ["swc_core/common_concurrent"]
 [dependencies]
 easy-error = "1.0.0"
 styled_jsx = { version = "0.29.0", path = "./transform" }
-swc_core = { version = "0.47.0", features = [
+swc_core = { version = "0.48.12", features = [
   "common",
   "ecma_ast",
   "css_ast",
@@ -32,5 +32,5 @@ swc_core = { version = "0.47.0", features = [
 tracing = { version = "0.1.37", features = ["release_max_level_off"] }
 
 [dev-dependencies]
-swc_core = { features = ["testing_transform"], version = "0.47.0" }
-testing = "0.31.20"
+swc_core = { features = ["testing_transform"], version = "0.48.12" }
+testing = "0.31.24"

--- a/packages/styled-jsx/transform/Cargo.toml
+++ b/packages/styled-jsx/transform/Cargo.toml
@@ -13,7 +13,7 @@ custom_transform = ["swc_core/common_concurrent"]
 easy-error = "1.0.0"
 tracing = "0.1.37"
 
-swc_core = { version = "0.47.0", features = [
+swc_core = { version = "0.48.12", features = [
   "common",
   "ecma_ast",
   "css_ast",
@@ -28,5 +28,5 @@ swc_core = { version = "0.47.0", features = [
 ] }
 
 [dev-dependencies]
-testing = "0.31.20"
-swc_core = { features = ["testing_transform"], version = "0.47.0" }
+testing = "0.31.24"
+swc_core = { features = ["testing_transform"], version = "0.48.12" }

--- a/packages/styled-jsx/transform/tests/fixture/tpl-placeholder-2-as-part-of-value/output.js
+++ b/packages/styled-jsx/transform/tests/fixture/tpl-placeholder-2-as-part-of-value/output.js
@@ -3,7 +3,7 @@ export default class {
     render() {
         return <div className={_JSXStyle.dynamic([
             [
-                "73606d02cbadabf",
+                "2afd62ca79f8b081",
                 [
                     a[b],
                     -1 * (c || 0),
@@ -14,7 +14,7 @@ export default class {
 
           <p className={_JSXStyle.dynamic([
             [
-                "73606d02cbadabf",
+                "2afd62ca79f8b081",
                 [
                     a[b],
                     -1 * (c || 0),
@@ -23,7 +23,7 @@ export default class {
             ]
         ])}>test</p>
 
-          <_JSXStyle id={"73606d02cbadabf"} dynamic={[
+          <_JSXStyle id={"2afd62ca79f8b081"} dynamic={[
             a[b],
             -1 * (c || 0),
             d

--- a/packages/transform-imports/Cargo.toml
+++ b/packages/transform-imports/Cargo.toml
@@ -13,8 +13,8 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 modularize_imports = { version = "0.25.0", path = "./transform" }
 serde_json = "1.0.79"
-swc_common = { version = "0.29.19", features = ["concurrent"] }
-swc_core = { version = "0.47.0", features = [
+swc_common = { version = "0.29.23", features = ["concurrent"] }
+swc_core = { version = "0.48.12", features = [
   "ecma_plugin_transform",
   "ecma_utils",
   "ecma_visit",

--- a/packages/transform-imports/transform/Cargo.toml
+++ b/packages/transform-imports/transform/Cargo.toml
@@ -19,8 +19,8 @@ swc_core = { features = [
   "cached",
   "ecma_ast",
   "ecma_visit",
-], version = "0.47.0" }
+], version = "0.48.12" }
 
 [dev-dependencies]
-swc_core = { features = ["testing_transform"], version = "0.47.0" }
-testing = "0.31.20"
+swc_core = { features = ["testing_transform"], version = "0.48.12" }
+testing = "0.31.24"


### PR DESCRIPTION
Supersede #123 + for the WEB-307.

#123 worked, but there seems some manual update required (for the test fixtures). Bump is needed anyway so took manual update.