### PR TITLE
feat: add ecma_parser deps

### DIFF
--- a/packages/transform-imports/transform/Cargo.toml
+++ b/packages/transform-imports/transform/Cargo.toml
@@ -22,5 +22,5 @@ swc_core = { features = [
 ], version = "0.52.8" }
 
 [dev-dependencies]
-swc_core = { features = ["testing_transform"], version = "0.52.8" }
+swc_core = { features = ["testing_transform", "ecma_parser"], version = "0.52.8" }
 testing = "0.31.28"


### PR DESCRIPTION
in the file `transform/tests/fixture.rs`, we use the ecma::parser relative methods, but not define dependencies, causing error with `cargo test`.

```
use swc_core::{
    ecma::parser::{EsConfig, Syntax},
    ecma::transforms::testing::{test_fixture, FixtureTestConfig},
};
```