### PR TITLE
fix(emotion): Autolabel filename label generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1656,7 +1656,7 @@ dependencies = [
 
 [[package]]
 name = "styled_jsx"
-version = "0.30.7"
+version = "0.30.8"
 dependencies = [
  "easy-error",
  "swc_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "modularize_imports"
-version = "0.26.7"
+version = "0.26.8"
 dependencies = [
  "convert_case",
  "handlebars",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2210,7 +2210,7 @@ dependencies = [
 
 [[package]]
 name = "swc_emotion"
-version = "0.29.7"
+version = "0.29.8"
 dependencies = [
  "base64",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1642,7 +1642,7 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "styled_components"
-version = "0.53.7"
+version = "0.53.8"
 dependencies = [
  "Inflector",
  "once_cell",

--- a/packages/emotion/package.json
+++ b/packages/emotion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-emotion",
-  "version": "2.5.44",
+  "version": "2.5.45",
   "description": "SWC plugin for emotion css-in-js library",
   "main": "swc_plugin_emotion.wasm",
   "scripts": {

--- a/packages/emotion/package.json
+++ b/packages/emotion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-emotion",
-  "version": "2.5.43",
+  "version": "2.5.44",
   "description": "SWC plugin for emotion css-in-js library",
   "main": "swc_plugin_emotion.wasm",
   "scripts": {

--- a/packages/emotion/transform/Cargo.toml
+++ b/packages/emotion/transform/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "swc_emotion"
 repository = "https://github.com/swc-project/plugins.git"
-version = "0.29.7"
+version = "0.29.8"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/packages/emotion/transform/Cargo.toml
+++ b/packages/emotion/transform/Cargo.toml
@@ -32,6 +32,7 @@ tracing = {version = "0.1.37", features = ["release_max_level_info"]}
 serde_json = "1"
 swc_core = { features = [
   "testing_transform",
+  "ecma_parser",
   "ecma_transforms_react",
 ], version = "0.59.14" }
 testing = "0.31.31"

--- a/packages/emotion/transform/src/lib.rs
+++ b/packages/emotion/transform/src/lib.rs
@@ -203,7 +203,7 @@ impl<C: Comments> EmotionTransformer<C> {
             filepath: path.to_owned(),
             dir: path.parent().and_then(|p| p.to_str()).map(|s| s.to_owned()),
             filename: path
-                .file_name()
+                .file_stem()
                 .and_then(|filename| filename.to_str())
                 .map(|s| s.to_owned()),
             cm,

--- a/packages/emotion/transform/tests/fixture.rs
+++ b/packages/emotion/transform/tests/fixture.rs
@@ -2,9 +2,13 @@ use std::path::PathBuf;
 
 use swc_core::{
     common::{chain, comments::SingleThreadedComments, Mark},
-    ecma::parser::{Syntax, TsConfig},
-    ecma::transforms::react::{jsx, Runtime},
-    ecma::transforms::testing::test_fixture,
+    ecma::{
+        parser::{Syntax, TsConfig},
+        transforms::{
+            react::{jsx, Runtime},
+            testing::test_fixture,
+        },
+    },
 };
 use swc_emotion::EmotionOptions;
 use testing::fixture;
@@ -48,6 +52,73 @@ fn next_emotion_fixture(input: PathBuf) {
                         sourcemap: Some(true),
                         auto_label: Some(true),
                         import_map: Some(test_import_map),
+                        ..Default::default()
+                    },
+                    &PathBuf::from("input.ts"),
+                    tr.cm.clone(),
+                    tr.comments.as_ref().clone(),
+                ),
+                jsx
+            )
+        },
+        &input,
+        &output,
+        Default::default(),
+    );
+}
+
+// Test the label format generation behaviour.
+// This uses the same input for each output, where each
+// output is validating the different labelling options.
+//
+// Each folder name in `/labels` specifies the label option being tested:
+//   "/labels/filename" -> "[filename]"
+//   "/labels/filename-local" -> "[filename]-[local]"
+//   "/labels/local" -> "[local]"
+#[fixture("tests/labels/**/output.js")]
+fn emotion_label_fixture(output: PathBuf) {
+    let output_folder = output.parent().unwrap();
+    let input = output_folder.parent().unwrap().join("input.tsx");
+
+    let label_option_raw = output_folder.file_name().unwrap().to_str().unwrap();
+    let label_option = if (output_folder.to_str().unwrap()).contains('-') {
+        // Multiple labelling specifiers, e.g. [filename]-[local]
+        label_option_raw
+            .split('-')
+            .map(|s| format!("[{s}]"))
+            .collect::<Vec<String>>()
+            .join("-")
+    } else {
+        // Singular labelling specifiers, e.g. [local]
+        format!("[{label_option_raw}]")
+    };
+
+    test_fixture(
+        ts_syntax(),
+        &|tr| {
+            let top_level_mark = Mark::fresh(Mark::root());
+            let jsx = jsx::<SingleThreadedComments>(
+                tr.cm.clone(),
+                Some(tr.comments.as_ref().clone()),
+                swc_core::ecma::transforms::react::Options {
+                    next: false.into(),
+                    runtime: Some(Runtime::Automatic),
+                    throw_if_namespace: false.into(),
+                    development: false.into(),
+                    use_builtins: true.into(),
+                    use_spread: true.into(),
+                    ..Default::default()
+                },
+                top_level_mark,
+            );
+
+            chain!(
+                swc_emotion::emotion(
+                    EmotionOptions {
+                        enabled: Some(true),
+                        sourcemap: Some(true),
+                        auto_label: Some(true),
+                        label_format: Some(label_option.to_string()),
                         ..Default::default()
                     },
                     &PathBuf::from("input.ts"),

--- a/packages/emotion/transform/tests/fixture.rs
+++ b/packages/emotion/transform/tests/fixture.rs
@@ -78,19 +78,25 @@ fn next_emotion_fixture(input: PathBuf) {
 #[fixture("tests/labels/**/output.js")]
 fn emotion_label_fixture(output: PathBuf) {
     let output_folder = output.parent().unwrap();
+    let output_folder_name = output_folder.file_name().unwrap().to_str().unwrap();
     let input = output_folder.parent().unwrap().join("input.tsx");
 
-    let label_option_raw = output_folder.file_name().unwrap().to_str().unwrap();
-    let label_option = if (output_folder.to_str().unwrap()).contains('-') {
+    // Simulate the input path for fairly represented maps in the fixture output.
+    let mut pseudo_input_path = PathBuf::from(output_folder);
+    pseudo_input_path.push("input.tsx");
+
+    dbg!(&pseudo_input_path);
+
+    let label_option = if output_folder_name.contains('-') {
         // Multiple labelling specifiers, e.g. [filename]-[local]
-        label_option_raw
+        output_folder_name
             .split('-')
             .map(|s| format!("[{s}]"))
             .collect::<Vec<String>>()
             .join("-")
     } else {
         // Singular labelling specifiers, e.g. [local]
-        format!("[{label_option_raw}]")
+        format!("[{output_folder_name}]")
     };
 
     test_fixture(
@@ -121,7 +127,7 @@ fn emotion_label_fixture(output: PathBuf) {
                         label_format: Some(label_option.to_string()),
                         ..Default::default()
                     },
-                    &PathBuf::from("input.ts"),
+                    &PathBuf::from(format!("{output_folder_name}/index.tsx")),
                     tr.cm.clone(),
                     tr.comments.as_ref().clone(),
                 ),

--- a/packages/emotion/transform/tests/labels/filename-local/output.js
+++ b/packages/emotion/transform/tests/labels/filename-local/output.js
@@ -1,8 +1,8 @@
 import styled from "@emotion/styled";
 export const StyledDiv = /*#__PURE__*/ styled("div", {
-  target: "ekie5mj0",
-  label: "input-StyledDiv",
+  target: "e1qx0n170",
+  label: "index-StyledDiv",
 })(
   "background-color:black;",
-  "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiaW5wdXQudHMiLCJzb3VyY2VzIjpbImlucHV0LnRzIl0sInNvdXJjZXNDb250ZW50IjpbImltcG9ydCBzdHlsZWQgZnJvbSBcIkBlbW90aW9uL3N0eWxlZFwiO1xuXG5leHBvcnQgY29uc3QgU3R5bGVkRGl2ID0gc3R5bGVkLmRpdmBcbiAgYmFja2dyb3VuZC1jb2xvcjogYmxhY2s7XG5gO1xuIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUV5QiJ9 */"
+  "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZmlsZW5hbWUtbG9jYWwvaW5kZXgudHN4Iiwic291cmNlcyI6WyJmaWxlbmFtZS1sb2NhbC9pbmRleC50c3giXSwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0IHN0eWxlZCBmcm9tIFwiQGVtb3Rpb24vc3R5bGVkXCI7XG5cbmV4cG9ydCBjb25zdCBTdHlsZWREaXYgPSBzdHlsZWQuZGl2YFxuICBiYWNrZ3JvdW5kLWNvbG9yOiBibGFjaztcbmA7XG4iXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBRXlCIn0= */"
 );

--- a/packages/emotion/transform/tests/labels/filename-local/output.js
+++ b/packages/emotion/transform/tests/labels/filename-local/output.js
@@ -1,0 +1,8 @@
+import styled from "@emotion/styled";
+export const StyledDiv = /*#__PURE__*/ styled("div", {
+  target: "ekie5mj0",
+  label: "input-StyledDiv",
+})(
+  "background-color:black;",
+  "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiaW5wdXQudHMiLCJzb3VyY2VzIjpbImlucHV0LnRzIl0sInNvdXJjZXNDb250ZW50IjpbImltcG9ydCBzdHlsZWQgZnJvbSBcIkBlbW90aW9uL3N0eWxlZFwiO1xuXG5leHBvcnQgY29uc3QgU3R5bGVkRGl2ID0gc3R5bGVkLmRpdmBcbiAgYmFja2dyb3VuZC1jb2xvcjogYmxhY2s7XG5gO1xuIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUV5QiJ9 */"
+);

--- a/packages/emotion/transform/tests/labels/filename/output.js
+++ b/packages/emotion/transform/tests/labels/filename/output.js
@@ -1,0 +1,8 @@
+import styled from "@emotion/styled";
+export const StyledDiv = /*#__PURE__*/ styled("div", {
+  target: "ekie5mj0",
+  label: "input",
+})(
+  "background-color:black;",
+  "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiaW5wdXQudHMiLCJzb3VyY2VzIjpbImlucHV0LnRzIl0sInNvdXJjZXNDb250ZW50IjpbImltcG9ydCBzdHlsZWQgZnJvbSBcIkBlbW90aW9uL3N0eWxlZFwiO1xuXG5leHBvcnQgY29uc3QgU3R5bGVkRGl2ID0gc3R5bGVkLmRpdmBcbiAgYmFja2dyb3VuZC1jb2xvcjogYmxhY2s7XG5gO1xuIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUV5QiJ9 */"
+);

--- a/packages/emotion/transform/tests/labels/filename/output.js
+++ b/packages/emotion/transform/tests/labels/filename/output.js
@@ -1,8 +1,8 @@
 import styled from "@emotion/styled";
 export const StyledDiv = /*#__PURE__*/ styled("div", {
-  target: "ekie5mj0",
-  label: "input",
+  target: "e159spl00",
+  label: "index",
 })(
   "background-color:black;",
-  "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiaW5wdXQudHMiLCJzb3VyY2VzIjpbImlucHV0LnRzIl0sInNvdXJjZXNDb250ZW50IjpbImltcG9ydCBzdHlsZWQgZnJvbSBcIkBlbW90aW9uL3N0eWxlZFwiO1xuXG5leHBvcnQgY29uc3QgU3R5bGVkRGl2ID0gc3R5bGVkLmRpdmBcbiAgYmFja2dyb3VuZC1jb2xvcjogYmxhY2s7XG5gO1xuIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUV5QiJ9 */"
+  "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZmlsZW5hbWUvaW5kZXgudHN4Iiwic291cmNlcyI6WyJmaWxlbmFtZS9pbmRleC50c3giXSwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0IHN0eWxlZCBmcm9tIFwiQGVtb3Rpb24vc3R5bGVkXCI7XG5cbmV4cG9ydCBjb25zdCBTdHlsZWREaXYgPSBzdHlsZWQuZGl2YFxuICBiYWNrZ3JvdW5kLWNvbG9yOiBibGFjaztcbmA7XG4iXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBRXlCIn0= */"
 );

--- a/packages/emotion/transform/tests/labels/input.tsx
+++ b/packages/emotion/transform/tests/labels/input.tsx
@@ -1,0 +1,5 @@
+import styled from "@emotion/styled";
+
+export const StyledDiv = styled.div`
+  background-color: black;
+`;

--- a/packages/emotion/transform/tests/labels/local/output.js
+++ b/packages/emotion/transform/tests/labels/local/output.js
@@ -1,0 +1,8 @@
+import styled from "@emotion/styled";
+export const StyledDiv = /*#__PURE__*/ styled("div", {
+  target: "ekie5mj0",
+  label: "StyledDiv",
+})(
+  "background-color:black;",
+  "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiaW5wdXQudHMiLCJzb3VyY2VzIjpbImlucHV0LnRzIl0sInNvdXJjZXNDb250ZW50IjpbImltcG9ydCBzdHlsZWQgZnJvbSBcIkBlbW90aW9uL3N0eWxlZFwiO1xuXG5leHBvcnQgY29uc3QgU3R5bGVkRGl2ID0gc3R5bGVkLmRpdmBcbiAgYmFja2dyb3VuZC1jb2xvcjogYmxhY2s7XG5gO1xuIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUV5QiJ9 */"
+);

--- a/packages/emotion/transform/tests/labels/local/output.js
+++ b/packages/emotion/transform/tests/labels/local/output.js
@@ -1,8 +1,8 @@
 import styled from "@emotion/styled";
 export const StyledDiv = /*#__PURE__*/ styled("div", {
-  target: "ekie5mj0",
+  target: "ecgc18h0",
   label: "StyledDiv",
 })(
   "background-color:black;",
-  "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiaW5wdXQudHMiLCJzb3VyY2VzIjpbImlucHV0LnRzIl0sInNvdXJjZXNDb250ZW50IjpbImltcG9ydCBzdHlsZWQgZnJvbSBcIkBlbW90aW9uL3N0eWxlZFwiO1xuXG5leHBvcnQgY29uc3QgU3R5bGVkRGl2ID0gc3R5bGVkLmRpdmBcbiAgYmFja2dyb3VuZC1jb2xvcjogYmxhY2s7XG5gO1xuIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUV5QiJ9 */"
+  "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoibG9jYWwvaW5kZXgudHN4Iiwic291cmNlcyI6WyJsb2NhbC9pbmRleC50c3giXSwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0IHN0eWxlZCBmcm9tIFwiQGVtb3Rpb24vc3R5bGVkXCI7XG5cbmV4cG9ydCBjb25zdCBTdHlsZWREaXYgPSBzdHlsZWQuZGl2YFxuICBiYWNrZ3JvdW5kLWNvbG9yOiBibGFjaztcbmA7XG4iXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBRXlCIn0= */"
 );

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-jest",
-  "version": "1.5.43",
+  "version": "1.5.44",
   "description": "SWC plugin for jest",
   "main": "swc_plugin_jest.wasm",
   "scripts": {

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-jest",
-  "version": "1.5.44",
+  "version": "1.5.45",
   "description": "SWC plugin for jest",
   "main": "swc_plugin_jest.wasm",
   "scripts": {

--- a/packages/loadable-components/package.json
+++ b/packages/loadable-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-loadable-components",
-  "version": "0.3.44",
+  "version": "0.3.45",
   "description": "SWC plugin for `@loadable/components`",
   "main": "swc_plugin_loadable_components.wasm",
   "scripts": {

--- a/packages/loadable-components/package.json
+++ b/packages/loadable-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-loadable-components",
-  "version": "0.3.43",
+  "version": "0.3.44",
   "description": "SWC plugin for `@loadable/components`",
   "main": "swc_plugin_loadable_components.wasm",
   "scripts": {

--- a/packages/noop/package.json
+++ b/packages/noop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-noop",
-  "version": "1.5.41",
+  "version": "1.5.42",
   "description": "Noop SWC plugin, for debugging",
   "main": "swc_plugin_noop.wasm",
   "scripts": {

--- a/packages/noop/package.json
+++ b/packages/noop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-noop",
-  "version": "1.5.42",
+  "version": "1.5.43",
   "description": "Noop SWC plugin, for debugging",
   "main": "swc_plugin_noop.wasm",
   "scripts": {

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-relay",
-  "version": "1.5.43",
+  "version": "1.5.44",
   "description": "SWC plugin for relay",
   "main": "swc_plugin_relay.wasm",
   "types": "./types.d.ts",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-relay",
-  "version": "1.5.44",
+  "version": "1.5.45",
   "description": "SWC plugin for relay",
   "main": "swc_plugin_relay.wasm",
   "types": "./types.d.ts",

--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-styled-components",
-  "version": "1.5.44",
+  "version": "1.5.45",
   "description": "SWC plugin for styled-components",
   "main": "swc_plugin_styled_components.wasm",
   "scripts": {

--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-styled-components",
-  "version": "1.5.43",
+  "version": "1.5.44",
   "description": "SWC plugin for styled-components",
   "main": "swc_plugin_styled_components.wasm",
   "scripts": {

--- a/packages/styled-components/transform/Cargo.toml
+++ b/packages/styled-components/transform/Cargo.toml
@@ -6,7 +6,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 license = "Apache-2.0"
 name = "styled_components"
 repository = "https://github.com/swc-project/plugins.git"
-version = "0.53.7"
+version = "0.53.8"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/packages/styled-jsx/package.json
+++ b/packages/styled-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-styled-jsx",
-  "version": "1.5.43",
+  "version": "1.5.44",
   "description": "SWC plugin for styled-jsx",
   "main": "swc_plugin_styled_jsx.wasm",
   "scripts": {

--- a/packages/styled-jsx/package.json
+++ b/packages/styled-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-styled-jsx",
-  "version": "1.5.44",
+  "version": "1.5.45",
   "description": "SWC plugin for styled-jsx",
   "main": "swc_plugin_styled_jsx.wasm",
   "scripts": {

--- a/packages/styled-jsx/transform/Cargo.toml
+++ b/packages/styled-jsx/transform/Cargo.toml
@@ -4,7 +4,7 @@ description = "AST transforms visitor for styled-jsx"
 edition = "2021"
 license = "Apache-2.0"
 name = "styled_jsx"
-version = "0.30.7"
+version = "0.30.8"
 
 [features]
 custom_transform = ["swc_core/common_concurrent"]

--- a/packages/transform-imports/package.json
+++ b/packages/transform-imports/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-transform-imports",
-  "version": "1.5.43",
+  "version": "1.5.44",
   "description": "SWC plugin for https://www.npmjs.com/package/babel-plugin-transform-imports",
   "main": "swc_plugin_transform_imports.wasm",
   "scripts": {

--- a/packages/transform-imports/package.json
+++ b/packages/transform-imports/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-transform-imports",
-  "version": "1.5.44",
+  "version": "1.5.45",
   "description": "SWC plugin for https://www.npmjs.com/package/babel-plugin-transform-imports",
   "main": "swc_plugin_transform_imports.wasm",
   "scripts": {

--- a/packages/transform-imports/transform/Cargo.toml
+++ b/packages/transform-imports/transform/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "modularize_imports"
 repository = "https://github.com/swc-project/plugins.git"
-version = "0.26.7"
+version = "0.26.8"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Currently the filename is taken with the extension, but this should be excluded.

Fixes #153 