### PR TITLE
fix(emotion): Autolabel dir vs dirname, ensure dirname is used over path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2210,7 +2210,7 @@ dependencies = [
 
 [[package]]
 name = "swc_emotion"
-version = "0.29.8"
+version = "0.29.9"
 dependencies = [
  "base64",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "modularize_imports"
-version = "0.26.8"
+version = "0.26.9"
 dependencies = [
  "convert_case",
  "handlebars",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1642,7 +1642,7 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "styled_components"
-version = "0.53.8"
+version = "0.53.9"
 dependencies = [
  "Inflector",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1656,7 +1656,7 @@ dependencies = [
 
 [[package]]
 name = "styled_jsx"
-version = "0.30.8"
+version = "0.30.9"
 dependencies = [
  "easy-error",
  "swc_core",

--- a/packages/emotion/package.json
+++ b/packages/emotion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-emotion",
-  "version": "2.5.45",
+  "version": "2.5.46",
   "description": "SWC plugin for emotion css-in-js library",
   "main": "swc_plugin_emotion.wasm",
   "scripts": {

--- a/packages/emotion/transform/Cargo.toml
+++ b/packages/emotion/transform/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "swc_emotion"
 repository = "https://github.com/swc-project/plugins.git"
-version = "0.29.8"
+version = "0.29.9"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/packages/emotion/transform/src/lib.rs
+++ b/packages/emotion/transform/src/lib.rs
@@ -201,7 +201,11 @@ impl<C: Comments> EmotionTransformer<C> {
             options,
             filepath_hash: None,
             filepath: path.to_owned(),
-            dirname: path.parent().and_then(|p| p.to_str()).map(|s| s.to_owned()),
+            dirname: path
+                .parent()
+                .and_then(|parent| parent.file_name())
+                .and_then(|dirname| dirname.to_str())
+                .map(|s| s.to_owned()),
             filename: path
                 .file_stem()
                 .and_then(|filename| filename.to_str())

--- a/packages/emotion/transform/src/lib.rs
+++ b/packages/emotion/transform/src/lib.rs
@@ -171,7 +171,7 @@ pub struct EmotionTransformer<C: Comments> {
     pub options: EmotionOptions,
     filepath_hash: Option<u32>,
     filepath: PathBuf,
-    dir: Option<String>,
+    dirname: Option<String>,
     filename: Option<String>,
     cm: Arc<SourceMapperDyn>,
     comments: C,
@@ -201,7 +201,7 @@ impl<C: Comments> EmotionTransformer<C> {
             options,
             filepath_hash: None,
             filepath: path.to_owned(),
-            dir: path.parent().and_then(|p| p.to_str()).map(|s| s.to_owned()),
+            dirname: path.parent().and_then(|p| p.to_str()).map(|s| s.to_owned()),
             filename: path
                 .file_stem()
                 .and_then(|filename| filename.to_str())
@@ -244,8 +244,8 @@ impl<C: Comments> EmotionTransformer<C> {
             if let Some(filename) = self.filename.as_ref() {
                 label = label.replace("[filename]", filename);
             }
-            if let Some(dir) = self.dir.as_ref() {
-                label = label.replace("[dir]", dir);
+            if let Some(dirname) = self.dirname.as_ref() {
+                label = label.replace("[dirname]", dirname);
             };
         }
         label

--- a/packages/emotion/transform/tests/fixture.rs
+++ b/packages/emotion/transform/tests/fixture.rs
@@ -72,6 +72,8 @@ fn next_emotion_fixture(input: PathBuf) {
 // output is validating the different labelling options.
 //
 // Each folder name in `/labels` specifies the label option being tested:
+//   "/labels/dirname" -> "[dirname]"
+//   "/labels/dirname-filename-local" -> "[dirname]-[filename]-[local]"
 //   "/labels/filename" -> "[filename]"
 //   "/labels/filename-local" -> "[filename]-[local]"
 //   "/labels/local" -> "[local]"
@@ -84,8 +86,6 @@ fn emotion_label_fixture(output: PathBuf) {
     // Simulate the input path for fairly represented maps in the fixture output.
     let mut pseudo_input_path = PathBuf::from(output_folder);
     pseudo_input_path.push("input.tsx");
-
-    dbg!(&pseudo_input_path);
 
     let label_option = if output_folder_name.contains('-') {
         // Multiple labelling specifiers, e.g. [filename]-[local]

--- a/packages/emotion/transform/tests/labels/dirname-filename-local/output.js
+++ b/packages/emotion/transform/tests/labels/dirname-filename-local/output.js
@@ -1,0 +1,8 @@
+import styled from "@emotion/styled";
+export const StyledDiv = /*#__PURE__*/ styled("div", {
+  target: "e1888tq0",
+  label: "dirname-filename-local-index-StyledDiv",
+})(
+  "background-color:black;",
+  "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZGlybmFtZS1maWxlbmFtZS1sb2NhbC9pbmRleC50c3giLCJzb3VyY2VzIjpbImRpcm5hbWUtZmlsZW5hbWUtbG9jYWwvaW5kZXgudHN4Il0sInNvdXJjZXNDb250ZW50IjpbImltcG9ydCBzdHlsZWQgZnJvbSBcIkBlbW90aW9uL3N0eWxlZFwiO1xuXG5leHBvcnQgY29uc3QgU3R5bGVkRGl2ID0gc3R5bGVkLmRpdmBcbiAgYmFja2dyb3VuZC1jb2xvcjogYmxhY2s7XG5gO1xuIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUV5QiJ9 */"
+);

--- a/packages/emotion/transform/tests/labels/dirname/output.js
+++ b/packages/emotion/transform/tests/labels/dirname/output.js
@@ -1,0 +1,8 @@
+import styled from "@emotion/styled";
+export const StyledDiv = /*#__PURE__*/ styled("div", {
+  target: "e1fpa18x0",
+  label: "dirname",
+})(
+  "background-color:black;",
+  "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZGlybmFtZS9pbmRleC50c3giLCJzb3VyY2VzIjpbImRpcm5hbWUvaW5kZXgudHN4Il0sInNvdXJjZXNDb250ZW50IjpbImltcG9ydCBzdHlsZWQgZnJvbSBcIkBlbW90aW9uL3N0eWxlZFwiO1xuXG5leHBvcnQgY29uc3QgU3R5bGVkRGl2ID0gc3R5bGVkLmRpdmBcbiAgYmFja2dyb3VuZC1jb2xvcjogYmxhY2s7XG5gO1xuIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUV5QiJ9 */"
+);

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-jest",
-  "version": "1.5.45",
+  "version": "1.5.46",
   "description": "SWC plugin for jest",
   "main": "swc_plugin_jest.wasm",
   "scripts": {

--- a/packages/loadable-components/package.json
+++ b/packages/loadable-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-loadable-components",
-  "version": "0.3.45",
+  "version": "0.3.46",
   "description": "SWC plugin for `@loadable/components`",
   "main": "swc_plugin_loadable_components.wasm",
   "scripts": {

--- a/packages/noop/package.json
+++ b/packages/noop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-noop",
-  "version": "1.5.43",
+  "version": "1.5.44",
   "description": "Noop SWC plugin, for debugging",
   "main": "swc_plugin_noop.wasm",
   "scripts": {

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-relay",
-  "version": "1.5.45",
+  "version": "1.5.46",
   "description": "SWC plugin for relay",
   "main": "swc_plugin_relay.wasm",
   "types": "./types.d.ts",

--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-styled-components",
-  "version": "1.5.45",
+  "version": "1.5.46",
   "description": "SWC plugin for styled-components",
   "main": "swc_plugin_styled_components.wasm",
   "scripts": {

--- a/packages/styled-components/transform/Cargo.toml
+++ b/packages/styled-components/transform/Cargo.toml
@@ -6,7 +6,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 license = "Apache-2.0"
 name = "styled_components"
 repository = "https://github.com/swc-project/plugins.git"
-version = "0.53.8"
+version = "0.53.9"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/packages/styled-jsx/package.json
+++ b/packages/styled-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-styled-jsx",
-  "version": "1.5.45",
+  "version": "1.5.46",
   "description": "SWC plugin for styled-jsx",
   "main": "swc_plugin_styled_jsx.wasm",
   "scripts": {

--- a/packages/styled-jsx/transform/Cargo.toml
+++ b/packages/styled-jsx/transform/Cargo.toml
@@ -4,7 +4,7 @@ description = "AST transforms visitor for styled-jsx"
 edition = "2021"
 license = "Apache-2.0"
 name = "styled_jsx"
-version = "0.30.8"
+version = "0.30.9"
 
 [features]
 custom_transform = ["swc_core/common_concurrent"]

--- a/packages/transform-imports/package.json
+++ b/packages/transform-imports/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-transform-imports",
-  "version": "1.5.45",
+  "version": "1.5.46",
   "description": "SWC plugin for https://www.npmjs.com/package/babel-plugin-transform-imports",
   "main": "swc_plugin_transform_imports.wasm",
   "scripts": {

--- a/packages/transform-imports/transform/Cargo.toml
+++ b/packages/transform-imports/transform/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "modularize_imports"
 repository = "https://github.com/swc-project/plugins.git"
-version = "0.26.8"
+version = "0.26.9"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
The current documentation and original emotion babel plugin documentation specify using `[dirname]` as a label token, however, the current implementation uses `[dir]`. I also found a case when testing where the parent would be selected with the remainder of the path if a full path was provided.

Resolve both of these, and add additional fixtures to test the output.