### PR TITLE
feat(relay): Port patches from next.js repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "modularize_imports"
-version = "0.26.12"
+version = "0.26.13"
 dependencies = [
  "convert_case",
  "handlebars",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2501,7 +2501,7 @@ dependencies = [
 
 [[package]]
 name = "swc_relay"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "once_cell",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1750,7 +1750,7 @@ dependencies = [
 
 [[package]]
 name = "styled_jsx"
-version = "0.30.12"
+version = "0.30.13"
 dependencies = [
  "easy-error",
  "swc_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1736,7 +1736,7 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "styled_components"
-version = "0.53.12"
+version = "0.53.13"
 dependencies = [
  "Inflector",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2307,7 +2307,7 @@ dependencies = [
 
 [[package]]
 name = "swc_emotion"
-version = "0.29.12"
+version = "0.29.13"
 dependencies = [
  "base64",
  "byteorder",

--- a/packages/emotion/package.json
+++ b/packages/emotion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-emotion",
-  "version": "2.5.49",
+  "version": "2.5.50",
   "description": "SWC plugin for emotion css-in-js library",
   "main": "swc_plugin_emotion.wasm",
   "scripts": {

--- a/packages/emotion/transform/Cargo.toml
+++ b/packages/emotion/transform/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "swc_emotion"
 repository = "https://github.com/swc-project/plugins.git"
-version = "0.29.12"
+version = "0.29.13"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-jest",
-  "version": "1.5.49",
+  "version": "1.5.50",
   "description": "SWC plugin for jest",
   "main": "swc_plugin_jest.wasm",
   "scripts": {

--- a/packages/loadable-components/package.json
+++ b/packages/loadable-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-loadable-components",
-  "version": "0.3.49",
+  "version": "0.3.50",
   "description": "SWC plugin for `@loadable/components`",
   "main": "swc_plugin_loadable_components.wasm",
   "scripts": {

--- a/packages/noop/package.json
+++ b/packages/noop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-noop",
-  "version": "1.5.47",
+  "version": "1.5.48",
   "description": "Noop SWC plugin, for debugging",
   "main": "swc_plugin_noop.wasm",
   "scripts": {

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-relay",
-  "version": "1.5.49",
+  "version": "1.5.50",
   "description": "SWC plugin for relay",
   "main": "swc_plugin_relay.wasm",
   "types": "./types.d.ts",

--- a/packages/relay/src/lib.rs
+++ b/packages/relay/src/lib.rs
@@ -50,7 +50,7 @@ fn relay_plugin_transform(program: Program, metadata: TransformPluginProgramMeta
         eager_es_modules,
     };
 
-    let mut relay = relay(&config, filename, root_dir);
+    let mut relay = relay(&config, filename, root_dir, None);
 
     program.fold_with(&mut relay)
 }

--- a/packages/relay/transform/Cargo.toml
+++ b/packages/relay/transform/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "swc_relay"
 repository = "https://github.com/swc-project/plugins.git"
-version = "0.1.0"
+version = "0.1.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/packages/relay/transform/src/lib.rs
+++ b/packages/relay/transform/src/lib.rs
@@ -70,6 +70,7 @@ impl RelayImport {
 
 struct Relay<'a> {
     root_dir: PathBuf,
+    pages_dir: Option<PathBuf>,
     file_name: FileName,
     config: &'a Config,
     imports: Vec<RelayImport>,
@@ -148,6 +149,7 @@ fn unique_ident_name_from_operation_name(operation_name: &str) -> String {
 #[derive(Debug)]
 enum BuildRequirePathError {
     FileNameNotReal,
+    ArtifactDirectoryExpected { file_name: String },
 }
 
 impl<'a> Relay<'a> {
@@ -168,6 +170,14 @@ impl<'a> Relay<'a> {
 
         if let Some(artifact_directory) = &self.config.artifact_directory {
             Ok(self.root_dir.join(artifact_directory).join(filename))
+        } else if self
+            .pages_dir
+            .as_ref()
+            .map_or(false, |pages_dir| real_file_name.starts_with(pages_dir))
+        {
+            Err(BuildRequirePathError::ArtifactDirectoryExpected {
+                file_name: real_file_name.display().to_string(),
+            })
         } else {
             Ok(real_file_name
                 .parent()
@@ -247,11 +257,17 @@ impl<'a> Relay<'a> {
     }
 }
 
-pub fn relay(config: &Config, file_name: FileName, root_dir: PathBuf) -> impl Fold + '_ {
+pub fn relay(
+    config: &Config,
+    file_name: FileName,
+    root_dir: PathBuf,
+    pages_dir: Option<PathBuf>,
+) -> impl Fold + '_ {
     Relay {
         root_dir,
         file_name,
         config,
+        pages_dir,
         imports: vec![],
     }
 }

--- a/packages/relay/transform/src/lib.rs
+++ b/packages/relay/transform/src/lib.rs
@@ -21,6 +21,7 @@ use swc_core::{
 #[serde(rename_all = "lowercase")]
 pub enum RelayLanguageConfig {
     TypeScript,
+    JavaScript,
     Flow,
 }
 
@@ -159,6 +160,9 @@ impl<'a> Relay<'a> {
             RelayLanguageConfig::Flow => format!("{}.graphql.js", definition_name),
             RelayLanguageConfig::TypeScript => {
                 format!("{}.graphql.ts", definition_name)
+            }
+            RelayLanguageConfig::JavaScript => {
+                format!("{}.graphql.js", definition_name)
             }
         };
 

--- a/packages/relay/transform/tests/fixture.rs
+++ b/packages/relay/transform/tests/fixture.rs
@@ -19,6 +19,7 @@ fn fixture(input: PathBuf) {
                 },
                 FileName::Real("file.js".parse().unwrap()),
                 Default::default(),
+                None,
             )
         },
         &input,
@@ -42,6 +43,7 @@ fn fixture_es_modules(input: PathBuf) {
                 },
                 FileName::Real("file.js".parse().unwrap()),
                 Default::default(),
+                None,
             )
         },
         &input,

--- a/packages/relay/types.d.ts
+++ b/packages/relay/types.d.ts
@@ -2,7 +2,7 @@ declare module "@swc/plugin-relay" {
   export interface Config {
     rootDir: string;
     artifactDirectory?: string;
-    language: "typescript" | "flow";
+    language: "typescript" | "javascrip" | "flow";
     eagerEsModules?: boolean;
   }
 }

--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-styled-components",
-  "version": "1.5.49",
+  "version": "1.5.50",
   "description": "SWC plugin for styled-components",
   "main": "swc_plugin_styled_components.wasm",
   "scripts": {

--- a/packages/styled-components/transform/Cargo.toml
+++ b/packages/styled-components/transform/Cargo.toml
@@ -6,7 +6,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 license = "Apache-2.0"
 name = "styled_components"
 repository = "https://github.com/swc-project/plugins.git"
-version = "0.53.12"
+version = "0.53.13"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/packages/styled-jsx/package.json
+++ b/packages/styled-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-styled-jsx",
-  "version": "1.5.49",
+  "version": "1.5.50",
   "description": "SWC plugin for styled-jsx",
   "main": "swc_plugin_styled_jsx.wasm",
   "scripts": {

--- a/packages/styled-jsx/transform/Cargo.toml
+++ b/packages/styled-jsx/transform/Cargo.toml
@@ -4,7 +4,7 @@ description = "AST transforms visitor for styled-jsx"
 edition = "2021"
 license = "Apache-2.0"
 name = "styled_jsx"
-version = "0.30.12"
+version = "0.30.13"
 
 [features]
 custom_transform = ["swc_core/common_concurrent"]

--- a/packages/transform-imports/package.json
+++ b/packages/transform-imports/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-transform-imports",
-  "version": "1.5.49",
+  "version": "1.5.50",
   "description": "SWC plugin for https://www.npmjs.com/package/babel-plugin-transform-imports",
   "main": "swc_plugin_transform_imports.wasm",
   "scripts": {

--- a/packages/transform-imports/transform/Cargo.toml
+++ b/packages/transform-imports/transform/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "modularize_imports"
 repository = "https://github.com/swc-project/plugins.git"
-version = "0.26.12"
+version = "0.26.13"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This applies https://github.com/vercel/next.js/pull/43116

@orionmiz Are you fine with applying the patch to `swc-project/plugins`? The repositories of the swc-project GitHub organization have CLA, unlike next.js.

(CLA exists only to skip steps like this...)