### PR TITLE
feat(relay): support unresolved mark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1698,7 +1698,7 @@ dependencies = [
 
 [[package]]
 name = "styled_components"
-version = "0.54.6"
+version = "0.54.7"
 dependencies = [
  "Inflector",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "modularize_imports"
-version = "0.27.6"
+version = "0.27.7"
 dependencies = [
  "convert_case",
  "handlebars",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "styled_jsx"
-version = "0.31.6"
+version = "0.31.7"
 dependencies = [
  "easy-error",
  "swc_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2461,7 +2461,7 @@ dependencies = [
 
 [[package]]
 name = "swc_relay"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "once_cell",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2267,7 +2267,7 @@ dependencies = [
 
 [[package]]
 name = "swc_emotion"
-version = "0.30.6"
+version = "0.30.7"
 dependencies = [
  "base64",
  "byteorder",

--- a/packages/emotion/package.json
+++ b/packages/emotion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-emotion",
-  "version": "2.5.60",
+  "version": "2.5.61",
   "description": "SWC plugin for emotion css-in-js library",
   "main": "swc_plugin_emotion.wasm",
   "scripts": {

--- a/packages/emotion/transform/Cargo.toml
+++ b/packages/emotion/transform/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "swc_emotion"
 repository = "https://github.com/swc-project/plugins.git"
-version = "0.30.6"
+version = "0.30.7"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-jest",
-  "version": "1.5.60",
+  "version": "1.5.61",
   "description": "SWC plugin for jest",
   "main": "swc_plugin_jest.wasm",
   "scripts": {

--- a/packages/loadable-components/package.json
+++ b/packages/loadable-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-loadable-components",
-  "version": "0.3.60",
+  "version": "0.3.61",
   "description": "SWC plugin for `@loadable/components`",
   "main": "swc_plugin_loadable_components.wasm",
   "scripts": {

--- a/packages/noop/package.json
+++ b/packages/noop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-noop",
-  "version": "1.5.58",
+  "version": "1.5.59",
   "description": "Noop SWC plugin, for debugging",
   "main": "swc_plugin_noop.wasm",
   "scripts": {

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-relay",
-  "version": "1.5.60",
+  "version": "1.5.61",
   "description": "SWC plugin for relay",
   "main": "swc_plugin_relay.wasm",
   "types": "./types.d.ts",

--- a/packages/relay/src/lib.rs
+++ b/packages/relay/src/lib.rs
@@ -50,7 +50,13 @@ fn relay_plugin_transform(program: Program, metadata: TransformPluginProgramMeta
         eager_es_modules,
     };
 
-    let mut relay = relay(&config, filename, root_dir, None);
+    let mut relay = relay(
+        &config,
+        filename,
+        root_dir,
+        None,
+        Some(metadata.unresolved_mark),
+    );
 
     program.fold_with(&mut relay)
 }

--- a/packages/relay/transform/Cargo.toml
+++ b/packages/relay/transform/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "swc_relay"
 repository = "https://github.com/swc-project/plugins.git"
-version = "0.2.6"
+version = "0.2.7"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/packages/relay/transform/tests/fixture.rs
+++ b/packages/relay/transform/tests/fixture.rs
@@ -20,6 +20,7 @@ fn fixture(input: PathBuf) {
                 FileName::Real("file.js".parse().unwrap()),
                 Default::default(),
                 None,
+                None,
             )
         },
         &input,
@@ -43,6 +44,7 @@ fn fixture_es_modules(input: PathBuf) {
                 },
                 FileName::Real("file.js".parse().unwrap()),
                 Default::default(),
+                None,
                 None,
             )
         },

--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-styled-components",
-  "version": "1.5.60",
+  "version": "1.5.61",
   "description": "SWC plugin for styled-components",
   "main": "swc_plugin_styled_components.wasm",
   "scripts": {

--- a/packages/styled-components/transform/Cargo.toml
+++ b/packages/styled-components/transform/Cargo.toml
@@ -6,7 +6,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 license = "Apache-2.0"
 name = "styled_components"
 repository = "https://github.com/swc-project/plugins.git"
-version = "0.54.6"
+version = "0.54.7"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/packages/styled-jsx/package.json
+++ b/packages/styled-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-styled-jsx",
-  "version": "1.5.60",
+  "version": "1.5.61",
   "description": "SWC plugin for styled-jsx",
   "main": "swc_plugin_styled_jsx.wasm",
   "scripts": {

--- a/packages/styled-jsx/transform/Cargo.toml
+++ b/packages/styled-jsx/transform/Cargo.toml
@@ -4,7 +4,7 @@ description = "AST transforms visitor for styled-jsx"
 edition = "2021"
 license = "Apache-2.0"
 name = "styled_jsx"
-version = "0.31.6"
+version = "0.31.7"
 
 [features]
 custom_transform = ["swc_core/common_concurrent"]

--- a/packages/transform-imports/package.json
+++ b/packages/transform-imports/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-transform-imports",
-  "version": "1.5.60",
+  "version": "1.5.61",
   "description": "SWC plugin for https://www.npmjs.com/package/babel-plugin-transform-imports",
   "main": "swc_plugin_transform_imports.wasm",
   "scripts": {

--- a/packages/transform-imports/transform/Cargo.toml
+++ b/packages/transform-imports/transform/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "modularize_imports"
 repository = "https://github.com/swc-project/plugins.git"
-version = "0.27.6"
+version = "0.27.7"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This PR expands `relay` plugin to pass mark for injecting new module imports. 

Unfortunately this makes interface (`relay`) breaking - maybe expose `Relay` struct itself as public and make it manually constructable would be the way to avoid breaking changes.