### PR TITLE
feat(transform-imports): Support mapping rules for individual import names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1687,7 +1687,7 @@ dependencies = [
 
 [[package]]
 name = "styled_components"
-version = "0.59.0"
+version = "0.60.0"
 dependencies = [
  "Inflector",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2453,7 +2453,7 @@ dependencies = [
 
 [[package]]
 name = "swc_relay"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "once_cell",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2259,7 +2259,7 @@ dependencies = [
 
 [[package]]
 name = "swc_emotion"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "base64",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1828,9 +1828,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.79.10"
+version = "0.79.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ef905a7106e91c8776227c7bafbb635ab2f5f38e95fe2b8851d6fbd7e602820"
+checksum = "86f973fad05a8429dde5a039efbc69cd3ab7c18de8f5b1cd7f9a8a24a64a36a6"
 dependencies = [
  "once_cell",
  "swc_atoms",
@@ -1979,9 +1979,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.142.2"
+version = "0.142.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f07839021e70d0970cd3565b3968e168db557f7c1cf190fa66e93f87670531"
+checksum = "f8149037ea6ff0c9238a9b2941bf3fd7b168d99490737c96bc73ebf48fe6b4eb"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -2011,9 +2011,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.184.8"
+version = "0.184.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325b7de871dccd577aacbfa3290104f0f0ae375178af0ff2f60d67ea3da3a872"
+checksum = "6cdefbc26fdd98419b558aa41ee151afe33beeb9a455abd0ce1f129a864f8ab5"
 dependencies = [
  "ahash 0.8.3",
  "arrayvec",
@@ -2046,9 +2046,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.137.2"
+version = "0.137.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae92607eb63b82b716129c5497f11a6ebc083a27fb87ece66b2d79954b01ea1c"
+checksum = "330a18477af59ac728818c5c219d180c104b42515950305c72365c0aaf8e51d6"
 dependencies = [
  "either",
  "lexical",
@@ -2066,9 +2066,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_quote_macros"
-version = "0.48.2"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891104ddecaa64a0c59ae9b39d01a6dbe1a7b8bdfe97556a57b76a835f5c3852"
+checksum = "3d2c58882c00678d7e0ef0fafb7156b5ffc6334652bef74007e8fc1fe8a4c280"
 dependencies = [
  "anyhow",
  "pmutil",
@@ -2097,9 +2097,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.130.2"
+version = "0.130.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "780de0309bd17e76563a6e3416824f9e808079b24c80ac9a1de8094dd96f0512"
+checksum = "0f4cf78dc213e3715dee818e33e84b0dcbad0dc2dc7bbb8da3fcb9acee33ab42"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.3.3",
@@ -2133,9 +2133,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.190.5"
+version = "0.190.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bad62c6cc45ce8ca032bb6ee576fcc600bf80d4781d48c7d86d4a41a1447fa0"
+checksum = "101d3a3f6d2aaa2b65dae3fb63a40a13c1a03aa65523bb481576077445ed1e5c"
 dependencies = [
  "ahash 0.8.3",
  "dashmap",
@@ -2158,9 +2158,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.176.4"
+version = "0.176.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42b813c1b41340d1976b7003d2d8c83c0894c0dd221386c97e8c74e707deb42a"
+checksum = "7f4dc1ea62ad7ea1e1a5bf338f998775c4faae5c1e9d4732630b6d4053aeb12a"
 dependencies = [
  "ahash 0.8.3",
  "base64",
@@ -2183,9 +2183,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.133.2"
+version = "0.133.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31fa20bd9ddcad28e21cfc30dcf2abd881ecffafe9b9333e71f46028474796a7"
+checksum = "806aaff958dd5a084c0796b353ddf437944a442a87aac90cdef60d3b8a37149a"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -2209,9 +2209,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_usage_analyzer"
-version = "0.16.3"
+version = "0.16.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b04e9b497be4134b2f4aac798f1379f0ba67d0e0a43293b761e3a7a99fa95ed6"
+checksum = "2468a14ae6b135ed237135a632a7d6c4f4bcb9d1c188bc76914d006af007ab32"
 dependencies = [
  "ahash 0.8.3",
  "indexmap",
@@ -2227,9 +2227,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.120.2"
+version = "0.120.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c9203b881a2bd07de18db0d5cb8df5dfada81efafc4be4cd74674215258033"
+checksum = "a389e920fb169028fb41e8511ddef2c8b5650e27ece640176038d9818709eb79"
 dependencies = [
  "indexmap",
  "num_cpus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1701,7 +1701,7 @@ dependencies = [
 
 [[package]]
 name = "styled_jsx"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "easy-error",
  "swc_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "modularize_imports"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "convert_case",
  "handlebars",

--- a/packages/emotion/Cargo.toml
+++ b/packages/emotion/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "rlib"]
 serde = "1"
 serde_json = "1.0.79"
 swc_common = { version = "0.31.17", features = ["concurrent"] }
-swc_core = { version = "0.79.10", features = [
+swc_core = { version = "0.79.20", features = [
   "ecma_plugin_transform",
   "ecma_utils",
   "ecma_visit",

--- a/packages/emotion/package.json
+++ b/packages/emotion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-emotion",
-  "version": "2.5.69",
+  "version": "2.5.70",
   "description": "SWC plugin for emotion css-in-js library",
   "main": "swc_plugin_emotion.wasm",
   "scripts": {

--- a/packages/emotion/transform/Cargo.toml
+++ b/packages/emotion/transform/Cargo.toml
@@ -25,7 +25,7 @@ swc_core = { features = [
   "ecma_utils",
   "ecma_visit",
   "trace_macro",
-], version = "0.79.10" }
+], version = "0.79.20" }
 tracing = { version = "0.1.37" }
 
 [dev-dependencies]
@@ -34,5 +34,5 @@ swc_core = { features = [
   "testing_transform",
   "ecma_parser",
   "ecma_transforms_react",
-], version = "0.79.10" }
+], version = "0.79.20" }
 testing = "0.33.20"

--- a/packages/emotion/transform/Cargo.toml
+++ b/packages/emotion/transform/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "swc_emotion"
 repository = "https://github.com/swc-project/plugins.git"
-version = "0.35.0"
+version = "0.36.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/packages/jest/Cargo.toml
+++ b/packages/jest/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "rlib"]
 phf = { version = "0.10.0", features = ["macros"] }
 serde = { version = "1.0.130", features = ["derive"] }
 swc_common = { version = "0.31.17", features = ["concurrent"] }
-swc_core = { version = "0.79.10", features = [
+swc_core = { version = "0.79.20", features = [
   "ecma_plugin_transform",
   "ecma_utils",
   "ecma_visit",

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-jest",
-  "version": "1.5.69",
+  "version": "1.5.70",
   "description": "SWC plugin for jest",
   "main": "swc_plugin_jest.wasm",
   "scripts": {

--- a/packages/loadable-components/Cargo.toml
+++ b/packages/loadable-components/Cargo.toml
@@ -15,7 +15,7 @@ once_cell = "1.13.1"
 regex = "1.6.0"
 serde_json = "1.0.79"
 swc_common = { version = "0.31.17", features = ["concurrent"] }
-swc_core = { version = "0.79.10", features = [
+swc_core = { version = "0.79.20", features = [
   "ecma_plugin_transform",
   "ecma_utils",
   "ecma_visit",

--- a/packages/loadable-components/package.json
+++ b/packages/loadable-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-loadable-components",
-  "version": "0.3.69",
+  "version": "0.3.70",
   "description": "SWC plugin for `@loadable/components`",
   "main": "swc_plugin_loadable_components.wasm",
   "scripts": {

--- a/packages/noop/Cargo.toml
+++ b/packages/noop/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 swc_common = { version = "0.31.17", features = ["concurrent"] }
-swc_core = { version = "0.79.10", features = [
+swc_core = { version = "0.79.20", features = [
   "ecma_plugin_transform",
   "ecma_utils",
   "ecma_visit",

--- a/packages/noop/package.json
+++ b/packages/noop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-noop",
-  "version": "1.5.67",
+  "version": "1.5.68",
   "description": "Noop SWC plugin, for debugging",
   "main": "swc_plugin_noop.wasm",
   "scripts": {

--- a/packages/relay/Cargo.toml
+++ b/packages/relay/Cargo.toml
@@ -16,7 +16,7 @@ regex = "1.5"
 serde = "1"
 serde_json = "1"
 swc_common = { version = "0.31.17", features = ["concurrent"] }
-swc_core = { version = "0.79.10", features = [
+swc_core = { version = "0.79.20", features = [
   "ecma_plugin_transform",
   "ecma_utils",
   "ecma_visit",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-relay",
-  "version": "1.5.69",
+  "version": "1.5.70",
   "description": "SWC plugin for relay",
   "main": "swc_plugin_relay.wasm",
   "types": "./types.d.ts",

--- a/packages/relay/transform/Cargo.toml
+++ b/packages/relay/transform/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "swc_relay"
 repository = "https://github.com/swc-project/plugins.git"
-version = "0.7.0"
+version = "0.8.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/packages/relay/transform/Cargo.toml
+++ b/packages/relay/transform/Cargo.toml
@@ -15,7 +15,7 @@ regex = "1.5"
 serde = "1"
 serde_json = "1"
 swc_common = { version = "0.31.17", features = ["concurrent"] }
-swc_core = { version = "0.79.10", features = [
+swc_core = { version = "0.79.20", features = [
   "ecma_utils",
   "ecma_visit",
   "ecma_ast",

--- a/packages/styled-components/Cargo.toml
+++ b/packages/styled-components/Cargo.toml
@@ -15,7 +15,7 @@ serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 styled_components = { path = "./transform" }
 swc_common = { version = "0.31.17", features = ["concurrent"] }
-swc_core = { version = "0.79.10", features = [
+swc_core = { version = "0.79.20", features = [
   "ecma_plugin_transform",
   "ecma_utils",
   "ecma_visit",

--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-styled-components",
-  "version": "1.5.69",
+  "version": "1.5.70",
   "description": "SWC plugin for styled-components",
   "main": "swc_plugin_styled_components.wasm",
   "scripts": {

--- a/packages/styled-components/transform/Cargo.toml
+++ b/packages/styled-components/transform/Cargo.toml
@@ -6,7 +6,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 license = "Apache-2.0"
 name = "styled_components"
 repository = "https://github.com/swc-project/plugins.git"
-version = "0.59.0"
+version = "0.60.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/packages/styled-components/transform/Cargo.toml
+++ b/packages/styled-components/transform/Cargo.toml
@@ -23,7 +23,7 @@ swc_core = { features = [
   "ecma_ast",
   "ecma_utils",
   "ecma_visit",
-], version = "0.79.10" }
+], version = "0.79.20" }
 tracing = "0.1.37"
 
 [dev-dependencies]
@@ -32,5 +32,5 @@ swc_core = { features = [
   "ecma_parser",
   "ecma_transforms",
   "testing_transform",
-], version = "0.79.10" }
+], version = "0.79.20" }
 testing = "0.33.20"

--- a/packages/styled-jsx/Cargo.toml
+++ b/packages/styled-jsx/Cargo.toml
@@ -16,7 +16,7 @@ custom_transform = ["swc_core/common_concurrent"]
 [dependencies]
 easy-error = "1.0.0"
 styled_jsx = { path = "./transform" }
-swc_core = { version = "0.79.10", features = [
+swc_core = { version = "0.79.20", features = [
   "common",
   "ecma_ast",
   "ecma_plugin_transform",
@@ -33,5 +33,5 @@ swc_core = { version = "0.79.10", features = [
 tracing = { version = "0.1.37", features = ["release_max_level_off"] }
 
 [dev-dependencies]
-swc_core = { features = ["testing_transform"], version = "0.79.10" }
+swc_core = { features = ["testing_transform"], version = "0.79.20" }
 testing = "0.33.20"

--- a/packages/styled-jsx/package.json
+++ b/packages/styled-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-styled-jsx",
-  "version": "1.5.69",
+  "version": "1.5.70",
   "description": "SWC plugin for styled-jsx",
   "main": "swc_plugin_styled_jsx.wasm",
   "scripts": {

--- a/packages/styled-jsx/transform/Cargo.toml
+++ b/packages/styled-jsx/transform/Cargo.toml
@@ -13,7 +13,7 @@ custom_transform = ["swc_core/common_concurrent"]
 easy-error = "1.0.0"
 tracing = "0.1.37"
 
-swc_core = { version = "0.79.10", features = [
+swc_core = { version = "0.79.20", features = [
   "common",
   "ecma_ast",
   "css_ast",
@@ -29,4 +29,4 @@ swc_core = { version = "0.79.10", features = [
 
 [dev-dependencies]
 testing = "0.33.20"
-swc_core = { features = ["testing_transform"], version = "0.79.10" }
+swc_core = { features = ["testing_transform"], version = "0.79.20" }

--- a/packages/styled-jsx/transform/Cargo.toml
+++ b/packages/styled-jsx/transform/Cargo.toml
@@ -4,7 +4,7 @@ description = "AST transforms visitor for styled-jsx"
 edition = "2021"
 license = "Apache-2.0"
 name = "styled_jsx"
-version = "0.36.0"
+version = "0.37.0"
 
 [features]
 custom_transform = ["swc_core/common_concurrent"]

--- a/packages/styled-jsx/transform/tests/fixture/styles/output.js
+++ b/packages/styled-jsx/transform/tests/fixture/styles/output.js
@@ -18,16 +18,16 @@ const b = {
     styles: <_JSXStyle id={"7a7480dd17e82e07"}>{`div.jsx-7a7480dd17e82e07{color:${colors.green.light}}a.jsx-7a7480dd17e82e07{color:red}`}</_JSXStyle>,
     className: "jsx-7a7480dd17e82e07"
 };
-const dynamic = (colors)=>{
+const dynamic = (colors1)=>{
     const b = {
         styles: <_JSXStyle id={"9f775f199a8dfb95"} dynamic={[
-            colors.green.light
-        ]}>{`div.__jsx-style-dynamic-selector{color:${colors.green.light}}a.__jsx-style-dynamic-selector{color:red}`}</_JSXStyle>,
+            colors1.green.light
+        ]}>{`div.__jsx-style-dynamic-selector{color:${colors1.green.light}}a.__jsx-style-dynamic-selector{color:red}`}</_JSXStyle>,
         className: _JSXStyle.dynamic([
             [
                 "9f775f199a8dfb95",
                 [
-                    colors.green.light
+                    colors1.green.light
                 ]
             ]
         ])

--- a/packages/transform-imports/Cargo.toml
+++ b/packages/transform-imports/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "rlib"]
 modularize_imports = { path = "./transform" }
 serde_json = "1.0.79"
 swc_common = { version = "0.31.17", features = ["concurrent"] }
-swc_core = { version = "0.79.10", features = [
+swc_core = { version = "0.79.20", features = [
   "ecma_plugin_transform",
   "ecma_utils",
   "ecma_visit",

--- a/packages/transform-imports/package.json
+++ b/packages/transform-imports/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-transform-imports",
-  "version": "1.5.69",
+  "version": "1.5.70",
   "description": "SWC plugin for https://www.npmjs.com/package/babel-plugin-transform-imports",
   "main": "swc_plugin_transform_imports.wasm",
   "scripts": {

--- a/packages/transform-imports/transform/Cargo.toml
+++ b/packages/transform-imports/transform/Cargo.toml
@@ -19,11 +19,11 @@ swc_core = { features = [
   "cached",
   "ecma_ast",
   "ecma_visit",
-], version = "0.79.10" }
+], version = "0.79.20" }
 
 [dev-dependencies]
 swc_core = { features = [
   "testing_transform",
   "ecma_parser",
-], version = "0.79.10" }
+], version = "0.79.20" }
 testing = "0.33.20"

--- a/packages/transform-imports/transform/Cargo.toml
+++ b/packages/transform-imports/transform/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "modularize_imports"
 repository = "https://github.com/swc-project/plugins.git"
-version = "0.32.0"
+version = "0.33.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/packages/transform-imports/transform/src/lib.rs
+++ b/packages/transform-imports/transform/src/lib.rs
@@ -5,11 +5,12 @@ use handlebars::{Context, Handlebars, Helper, HelperResult, Output, RenderContex
 use once_cell::sync::Lazy;
 use regex::{Captures, Regex};
 use serde::{Deserialize, Serialize};
-
 use swc_core::{
     cached::regex::CachedRegex,
-    ecma::ast::*,
-    ecma::visit::{noop_fold_type, Fold},
+    ecma::{
+        ast::*,
+        visit::{noop_fold_type, Fold},
+    },
 };
 
 static DUP_SLASH_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"//").unwrap());
@@ -23,11 +24,29 @@ pub struct Config {
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PackageConfig {
-    pub transform: String,
+    pub transform: Transform,
     #[serde(default)]
     pub prevent_full_import: bool,
     #[serde(default)]
     pub skip_default_conversion: bool,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(untagged)]
+pub enum Transform {
+    String(String),
+    Vec(Vec<(String, String)>),
+}
+
+impl From<&str> for Transform {
+    fn from(s: &str) -> Self {
+        Transform::String(s.to_string())
+    }
+}
+impl From<Vec<(String, String)>> for Transform {
+    fn from(v: Vec<(String, String)>) -> Self {
+        Transform::Vec(v)
+    }
 }
 
 struct FoldImports {
@@ -59,27 +78,86 @@ impl<'a> Rewriter<'a> {
                         Plain(&'a str),
                         Array(&'a [&'a str]),
                     }
+                    let name_str = named_spec
+                        .imported
+                        .as_ref()
+                        .map(|x| match x {
+                            ModuleExportName::Ident(x) => x.as_ref(),
+                            ModuleExportName::Str(x) => x.value.as_ref(),
+                        })
+                        .unwrap_or_else(|| named_spec.local.as_ref());
+
                     let mut ctx: HashMap<&str, Data> = HashMap::new();
                     ctx.insert("matches", Data::Array(&self.group[..]));
-                    ctx.insert(
-                        "member",
-                        Data::Plain(
-                            named_spec
-                                .imported
-                                .as_ref()
-                                .map(|x| match x {
-                                    ModuleExportName::Ident(x) => x.as_ref(),
-                                    ModuleExportName::Str(x) => x.value.as_ref(),
-                                })
-                                .unwrap_or_else(|| named_spec.local.as_ref()),
-                        ),
-                    );
-                    let new_path = self
-                        .renderer
-                        .render_template(&self.config.transform, &ctx)
-                        .unwrap_or_else(|e| {
-                            panic!("error rendering template for '{}': {}", self.key, e);
-                        });
+                    ctx.insert("member", Data::Plain(name_str));
+
+                    let new_path = match &self.config.transform {
+                        Transform::String(s) => {
+                            self.renderer.render_template(&s, &ctx).unwrap_or_else(|e| {
+                                panic!("error rendering template for '{}': {}", self.key, e);
+                            })
+                        }
+                        Transform::Vec(v) => {
+                            let mut result: Option<String> = None;
+
+                            // We iterate over the items to find the first match
+                            v.iter().any(|(k, val)| {
+                                let mut key = k.to_string();
+                                if !key.starts_with('^') && !key.ends_with('$') {
+                                    key = format!("^{}$", key);
+                                }
+
+                                // Create a clone of the context, as we need to insert the
+                                // `memberMatches` key for each key we try.
+                                let mut ctx_with_member_matches: HashMap<&str, Data> =
+                                    HashMap::new();
+                                ctx_with_member_matches
+                                    .insert("matches", Data::Array(&self.group[..]));
+                                ctx_with_member_matches.insert("member", Data::Plain(name_str));
+
+                                let regex = CachedRegex::new(&key)
+                                    .expect("transform-imports: invalid regex");
+                                let group = regex.captures(name_str);
+
+                                println!("!!!!key: {} {:?}, {}", key, group, name_str);
+
+                                if let Some(group) = group {
+                                    let group = group
+                                        .iter()
+                                        .map(|x| x.map(|x| x.as_str()).unwrap_or_default())
+                                        .collect::<Vec<&str>>()
+                                        .clone();
+                                    ctx_with_member_matches
+                                        .insert("memberMatches", Data::Array(&group[..]));
+
+                                    result = Some(
+                                        self.renderer
+                                            .render_template(&val, &ctx_with_member_matches)
+                                            .unwrap_or_else(|e| {
+                                                panic!(
+                                                    "error rendering template for '{}': {}",
+                                                    self.key, e
+                                                );
+                                            }),
+                                    );
+
+                                    true
+                                } else {
+                                    false
+                                }
+                            });
+
+                            if let Some(result) = result {
+                                result
+                            } else {
+                                panic!(
+                                    "missing transform for import '{}' of package '{}'",
+                                    named_spec.local, self.key
+                                );
+                            }
+                        }
+                    };
+
                     let new_path = DUP_SLASH_REGEX.replace_all(&new_path, |_: &Captures| "/");
                     let specifier = if self.config.skip_default_conversion {
                         ImportSpecifier::Named(named_spec.clone())
@@ -137,6 +215,7 @@ impl FoldImports {
 
 impl Fold for FoldImports {
     noop_fold_type!();
+
     fn fold_module(&mut self, mut module: Module) -> Module {
         let mut new_items: Vec<ModuleItem> = vec![];
         for item in module.body {

--- a/packages/transform-imports/transform/src/lib.rs
+++ b/packages/transform-imports/transform/src/lib.rs
@@ -93,7 +93,7 @@ impl<'a> Rewriter<'a> {
 
                     let new_path = match &self.config.transform {
                         Transform::String(s) => {
-                            self.renderer.render_template(&s, &ctx).unwrap_or_else(|e| {
+                            self.renderer.render_template(s, &ctx).unwrap_or_else(|e| {
                                 panic!("error rendering template for '{}': {}", self.key, e);
                             })
                         }
@@ -119,8 +119,6 @@ impl<'a> Rewriter<'a> {
                                     .expect("transform-imports: invalid regex");
                                 let group = regex.captures(name_str);
 
-                                println!("!!!!key: {} {:?}, {}", key, group, name_str);
-
                                 if let Some(group) = group {
                                     let group = group
                                         .iter()
@@ -132,7 +130,7 @@ impl<'a> Rewriter<'a> {
 
                                     result = Some(
                                         self.renderer
-                                            .render_template(&val, &ctx_with_member_matches)
+                                            .render_template(val, &ctx_with_member_matches)
                                             .unwrap_or_else(|e| {
                                                 panic!(
                                                     "error rendering template for '{}': {}",

--- a/packages/transform-imports/transform/tests/fixture.rs
+++ b/packages/transform-imports/transform/tests/fixture.rs
@@ -1,9 +1,9 @@
 use std::path::PathBuf;
 
 use modularize_imports::{modularize_imports, PackageConfig};
-use swc_core::{
-    ecma::parser::{EsConfig, Syntax},
-    ecma::transforms::testing::{test_fixture, FixtureTestConfig},
+use swc_core::ecma::{
+    parser::{EsConfig, Syntax},
+    transforms::testing::{test_fixture, FixtureTestConfig},
 };
 use testing::fixture;
 
@@ -50,6 +50,32 @@ fn modularize_imports_fixture(input: PathBuf) {
                         "my-library-3".to_string(),
                         PackageConfig {
                             transform: "my-library-3/{{ kebabCase member }}".into(),
+                            prevent_full_import: false,
+                            skip_default_conversion: true,
+                        },
+                    ),
+                    (
+                        "my-library-4".to_string(),
+                        PackageConfig {
+                            transform: Vec::from([
+                                ("foo".to_string(), "my-library-4/this_is_foo".to_string()),
+                                ("bar".to_string(), "my-library-4/bar".to_string()),
+                                (
+                                    "use(\\w*)".to_string(),
+                                    "my-library-4/{{ kebabCase member }}/{{ kebabCase \
+                                     memberMatches.[1] }}"
+                                        .to_string(),
+                                ),
+                                (
+                                    "(\\w*)Icon".to_string(),
+                                    "my-library-4/{{ kebabCase memberMatches.[1] }}".to_string(),
+                                ),
+                                (
+                                    "*".to_string(),
+                                    "my-library-4/{{ upperCase member }}".to_string(),
+                                ),
+                            ])
+                            .into(),
                             prevent_full_import: false,
                             skip_default_conversion: true,
                         },

--- a/packages/transform-imports/transform/tests/fixture/mapping/input.js
+++ b/packages/transform-imports/transform/tests/fixture/mapping/input.js
@@ -1,0 +1,4 @@
+import { foo, bar } from 'my-library-4'
+import { otherImport } from 'my-library-4'
+import { useSomeAPI } from 'my-library-4'
+import { ArrowUpIcon } from 'my-library-4'

--- a/packages/transform-imports/transform/tests/fixture/mapping/output.js
+++ b/packages/transform-imports/transform/tests/fixture/mapping/output.js
@@ -1,0 +1,5 @@
+import { foo } from "my-library-4/this_is_foo";
+import { bar } from "my-library-4/bar";
+import { otherImport } from "my-library-4/OTHERIMPORT";
+import { useSomeAPI } from "my-library-4/use-some-api/some-api";
+import { ArrowUpIcon } from "my-library-4/arrow-up";


### PR DESCRIPTION
## Current Problem

Currently, we only have one `transform: '...'` rule applied to all import names of a module import declaration. This implies that all exports of that module will follow the same rule, which is usually not the case.

Here're examples of some popular libraries:
- [lucide-react](https://unpkg.com/browse/lucide-react@0.252.0/dist/esm/lucide-react.js): `Accessibility`, `AccessibilityIcon` and `LucideAccessibility` all map to `'/icons/accessibility'`
- [react-bootstrap](https://unpkg.com/browse/react-bootstrap@2.8.0/esm/index.js): special case for `useAccordionButton`
- [@mui/material](https://unpkg.com/browse/@mui/material@5.14.1/index.js): `export *` expressions

To solve these problems, the original Babel plugin [supports using a function as the transformer](https://www.npmjs.com/package/babel-plugin-transform-imports#using-a-function-as-the-transformer) which brings the flexibility. We can't do the same but this PR adds an (almost) equivalent API.

## API

Instead of using just a string for `transform`, this PR extends it to accept an array of tuples that can match individual import names:

```js
'my-library/?(((\\w*)?/?)*)': {
  transform: [
    ["use(*)", "my-library/hooks/{{ kebabCase memberMatches.[1] }}"],
    ["(*)Icon", "my-library/icons/{{ memberMatches.[1] }}"],
    ["*", "my-library/{{ matches.[1] }}/{{ member }}"],
  ],
},
```

It will attempt to match each import in order and do the corresponding transform. The new `memberMatches` value is similar to the existing `matches` but it's from the imported name, rather than the module path. All Handlebars helpers are still available.

With the configuration above, for example `import { useFooBar } from 'my-library/baz'` will be transpiled as `import { useFooBar } from 'my-library/hooks/foo-bar'`.

It's recommended to have a `*` condition by the end to match all leftover cases. It can be pointing to the original lib path for compatibility.

This new API is added in a non-breaking way so all existing code should continue to work.