### PR TITLE
 feat(relay): Add `outputFileExtension` option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2157,7 +2157,7 @@ dependencies = [
 
 [[package]]
 name = "styled_jsx"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "easy-error",
  "lightningcss",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2136,7 +2136,7 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "styled_components"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "Inflector",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2762,7 +2762,7 @@ dependencies = [
 
 [[package]]
 name = "swc_emotion"
-version = "0.54.0"
+version = "0.55.0"
 dependencies = [
  "base64",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2300,7 +2300,7 @@ dependencies = [
 
 [[package]]
 name = "swc_constify"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "once_cell",
  "rustc-hash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2838,7 +2838,7 @@ dependencies = [
 
 [[package]]
 name = "swc_magic"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "swc_atoms",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1743,7 +1743,7 @@ checksum = "c707298afce11da2efef2f600116fa93ffa7a032b5d7b628aa17711ec81383ca"
 
 [[package]]
 name = "remove_console"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "serde",
  "swc_atoms",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1668,7 +1668,7 @@ dependencies = [
 
 [[package]]
 name = "react_remove_properties"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "serde",
  "swc_atoms",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "modularize_imports"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "convert_case",
  "handlebars",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3075,7 +3075,7 @@ dependencies = [
 
 [[package]]
 name = "swc_relay"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "once_cell",
  "regex",

--- a/packages/constify/package.json
+++ b/packages/constify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-constify",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "SWC plugin for optimization",
   "main": "swc_plugin_constify.wasm",
   "scripts": {

--- a/packages/constify/transform/Cargo.toml
+++ b/packages/constify/transform/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "swc_constify"
 repository = "https://github.com/swc-project/plugins.git"
-version = "0.18.0"
+version = "0.19.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/packages/emotion/package.json
+++ b/packages/emotion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-emotion",
-  "version": "2.5.93",
+  "version": "2.5.94",
   "description": "SWC plugin for emotion css-in-js library",
   "main": "swc_plugin_emotion.wasm",
   "scripts": {

--- a/packages/emotion/transform/Cargo.toml
+++ b/packages/emotion/transform/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "swc_emotion"
 repository = "https://github.com/swc-project/plugins.git"
-version = "0.54.0"
+version = "0.55.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-jest",
-  "version": "1.5.93",
+  "version": "1.5.94",
   "description": "SWC plugin for jest",
   "main": "swc_plugin_jest.wasm",
   "scripts": {

--- a/packages/loadable-components/package.json
+++ b/packages/loadable-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-loadable-components",
-  "version": "0.3.93",
+  "version": "0.3.94",
   "description": "SWC plugin for `@loadable/components`",
   "main": "swc_plugin_loadable_components.wasm",
   "scripts": {

--- a/packages/noop/package.json
+++ b/packages/noop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-noop",
-  "version": "1.5.91",
+  "version": "1.5.92",
   "description": "Noop SWC plugin, for debugging",
   "main": "swc_plugin_noop.wasm",
   "scripts": {

--- a/packages/react-remove-properties/package.json
+++ b/packages/react-remove-properties/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-react-remove-properties",
-  "version": "1.5.93",
+  "version": "1.5.94",
   "description": "SWC plugin for https://www.npmjs.com/package/babel-plugin-react-remove-properties",
   "main": "swc_plugin_react_remove_properties.wasm",
   "scripts": {

--- a/packages/react-remove-properties/transform/Cargo.toml
+++ b/packages/react-remove-properties/transform/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "react_remove_properties"
 repository = "https://github.com/swc-project/plugins.git"
-version = "0.6.0"
+version = "0.7.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/packages/relay/README.md
+++ b/packages/relay/README.md
@@ -63,3 +63,24 @@ const swcConfig = require("./.swcrc.js")
 ```
 
 > Note: We're using a `.swcrc.js` file extension up above and importing the config directly because Relay needs access to `__dirname`, which can't be derived from the default JSON parsed from `.swcrc`.
+
+#### Output import paths
+
+By default, `@swc/plugin-relay` will transpile import paths based on the `language` option.
+You can use `outputFileExtension` to change the file extension of the generated import paths.
+
+```js
+plugins: [
+    [
+        "@swc/plugin-relay",
+        {
+            rootDir: __dirname,
+            artifactDirectory: "src/__generated__",
+            language: "typescript",
+            eagerEsModules: true,
+            outputFileExtension: "js",
+        },
+    ],
+],
+```
+In this example typescript graphql files will output transpiled import path of `javascript` ending with `.js`.

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-relay",
-  "version": "1.5.93",
+  "version": "1.5.94",
   "description": "SWC plugin for relay",
   "main": "swc_plugin_relay.wasm",
   "types": "./types.d.ts",

--- a/packages/relay/src/lib.rs
+++ b/packages/relay/src/lib.rs
@@ -6,7 +6,7 @@ use swc_core::{
     ecma::{ast::Program, visit::FoldWith},
     plugin::{plugin_transform, proxies::TransformPluginProgramMetadata},
 };
-use swc_relay::{relay, Config, RelayLanguageConfig};
+use swc_relay::{relay, Config, RelayLanguageConfig, OutputFileExtension};
 
 #[plugin_transform]
 fn relay_plugin_transform(program: Program, metadata: TransformPluginProgramMetadata) -> Program {
@@ -40,6 +40,9 @@ fn relay_plugin_transform(program: Program, metadata: TransformPluginProgramMeta
     let language = plugin_config["language"]
         .as_str()
         .map_or(RelayLanguageConfig::TypeScript, |v| v.try_into().unwrap());
+    let output_file_extension = plugin_config["outputFileExtension"]
+        .as_str()
+        .map_or(OutputFileExtension::Undefined, |v| v.try_into().unwrap());
     let eager_es_modules = plugin_config["eagerEsModules"]
         .as_bool()
         .unwrap_or_default();
@@ -48,6 +51,7 @@ fn relay_plugin_transform(program: Program, metadata: TransformPluginProgramMeta
         artifact_directory,
         language,
         eager_es_modules,
+        output_file_extension
     };
 
     let mut relay = relay(

--- a/packages/relay/transform/Cargo.toml
+++ b/packages/relay/transform/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "swc_relay"
 repository = "https://github.com/swc-project/plugins.git"
-version = "0.26.0"
+version = "0.27.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/packages/relay/transform/src/lib.rs
+++ b/packages/relay/transform/src/lib.rs
@@ -162,7 +162,7 @@ impl<'a> Relay<'a> {
         let filename = match &self.config.language {
             RelayLanguageConfig::Flow => format!("{}.graphql.js", definition_name),
             RelayLanguageConfig::TypeScript => {
-                format!("{}.graphql.ts", definition_name)
+                format!("{}.graphql", definition_name)
             }
             RelayLanguageConfig::JavaScript => {
                 format!("{}.graphql.js", definition_name)

--- a/packages/relay/transform/src/lib.rs
+++ b/packages/relay/transform/src/lib.rs
@@ -21,6 +21,14 @@ pub enum RelayLanguageConfig {
     Flow,
 }
 
+#[derive(Copy, Clone, Debug, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum OutputFileExtension {
+    TypeScript,
+    JavaScript,
+    Undefined
+}
+
 impl<'a> TryFrom<&'a str> for RelayLanguageConfig {
     type Error = String;
 
@@ -33,9 +41,28 @@ impl<'a> TryFrom<&'a str> for RelayLanguageConfig {
     }
 }
 
+
+impl<'a> TryFrom<&'a str> for OutputFileExtension {
+    type Error = String;
+
+    fn try_from(value: &'a str) -> Result<Self, Self::Error> {
+        match value {
+            "ts" => Ok(Self::TypeScript),
+            "js" => Ok(Self::JavaScript),
+            _ => Err(format!("Unexpected output file extension value '{}'", value)),
+        }
+    }
+}
+
 impl Default for RelayLanguageConfig {
     fn default() -> Self {
         Self::Flow
+    }
+}
+
+impl Default for OutputFileExtension {
+    fn default() -> Self {
+        Self::Undefined
     }
 }
 
@@ -81,6 +108,8 @@ pub struct Config {
     pub language: RelayLanguageConfig,
     #[serde(default)]
     pub eager_es_modules: bool,
+    #[serde(default)]
+    pub output_file_extension: OutputFileExtension,
 }
 
 fn pull_first_operation_name_from_tpl(tpl: &TaggedTpl) -> Option<String> {
@@ -159,14 +188,14 @@ impl<'a> Relay<'a> {
         real_file_name: &Path,
         definition_name: &str,
     ) -> Result<PathBuf, BuildRequirePathError> {
-        let filename = match &self.config.language {
-            RelayLanguageConfig::Flow => format!("{}.graphql.js", definition_name),
-            RelayLanguageConfig::TypeScript => {
-                format!("{}.graphql", definition_name)
-            }
-            RelayLanguageConfig::JavaScript => {
-                format!("{}.graphql.js", definition_name)
-            }
+        let filename = match &self.config.output_file_extension {
+            OutputFileExtension::JavaScript => format!("{}.graphql.js", definition_name),
+            OutputFileExtension::TypeScript => format!("{}.graphql.ts", definition_name),
+            OutputFileExtension::Undefined => match &self.config.language {
+                RelayLanguageConfig::Flow => format!("{}.graphql.js", definition_name),
+                RelayLanguageConfig::TypeScript => format!("{}.graphql.ts", definition_name),
+                RelayLanguageConfig::JavaScript => format!("{}.graphql.js", definition_name),
+            },
         };
 
         if let Some(artifact_directory) = &self.config.artifact_directory {

--- a/packages/relay/transform/tests/fixture.rs
+++ b/packages/relay/transform/tests/fixture.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use swc_common::FileName;
 use swc_ecma_transforms_testing::test_fixture;
-use swc_relay::{relay, Config, RelayLanguageConfig};
+use swc_relay::{relay, Config, RelayLanguageConfig, OutputFileExtension};
 
 #[testing::fixture("tests/fixture/simple/**/input.js")]
 fn fixture(input: PathBuf) {
@@ -16,6 +16,7 @@ fn fixture(input: PathBuf) {
                     artifact_directory: None,
                     language: RelayLanguageConfig::TypeScript,
                     eager_es_modules: false,
+                    output_file_extension: OutputFileExtension::Undefined,
                 },
                 FileName::Real("file.js".parse().unwrap()),
                 Default::default(),
@@ -41,6 +42,59 @@ fn fixture_es_modules(input: PathBuf) {
                     artifact_directory: None,
                     language: RelayLanguageConfig::TypeScript,
                     eager_es_modules: true,
+                    output_file_extension: OutputFileExtension::Undefined,
+                },
+                FileName::Real("file.js".parse().unwrap()),
+                Default::default(),
+                None,
+                None,
+            )
+        },
+        &input,
+        &output,
+        Default::default(),
+    );
+}
+
+#[testing::fixture("tests/fixture/outputFileExtension/javascript/**/input.js")]
+fn fixture_output_file_extension_javascript(input: PathBuf) {
+    let output = input.parent().unwrap().join("output.js");
+
+    test_fixture(
+        Default::default(),
+        &|_| {
+            relay(
+                &Config {
+                    artifact_directory: None,
+                    language: RelayLanguageConfig::TypeScript,
+                    eager_es_modules: true,
+                    output_file_extension: OutputFileExtension::JavaScript,
+                },
+                FileName::Real("file.js".parse().unwrap()),
+                Default::default(),
+                None,
+                None,
+            )
+        },
+        &input,
+        &output,
+        Default::default(),
+    );
+}
+
+#[testing::fixture("tests/fixture/outputFileExtension/typescript/**/input.js")]
+fn fixture_output_file_extension_typescript(input: PathBuf) {
+    let output = input.parent().unwrap().join("output.js");
+
+    test_fixture(
+        Default::default(),
+        &|_| {
+            relay(
+                &Config {
+                    artifact_directory: None,
+                    language: RelayLanguageConfig::JavaScript,
+                    eager_es_modules: true,
+                    output_file_extension: OutputFileExtension::TypeScript,
                 },
                 FileName::Real("file.js".parse().unwrap()),
                 Default::default(),

--- a/packages/relay/transform/tests/fixture/outputFileExtension/javascript/input.js
+++ b/packages/relay/transform/tests/fixture/outputFileExtension/javascript/input.js
@@ -1,0 +1,10 @@
+const myFragment = graphql`
+  fragment FooFragment on Bar {
+    id
+  }
+`
+useQuery(graphql`
+  query FooQuery {
+    id
+  }
+`)

--- a/packages/relay/transform/tests/fixture/outputFileExtension/javascript/output.js
+++ b/packages/relay/transform/tests/fixture/outputFileExtension/javascript/output.js
@@ -1,0 +1,4 @@
+import __FooFragment from "__generated__/FooFragment.graphql.js";
+import __FooQuery from "__generated__/FooQuery.graphql.js";
+const myFragment = __FooFragment;
+useQuery(__FooQuery);

--- a/packages/relay/transform/tests/fixture/outputFileExtension/typescript/input.js
+++ b/packages/relay/transform/tests/fixture/outputFileExtension/typescript/input.js
@@ -1,0 +1,10 @@
+const myFragment = graphql`
+  fragment FooFragment on Bar {
+    id
+  }
+`
+useQuery(graphql`
+  query FooQuery {
+    id
+  }
+`)

--- a/packages/relay/transform/tests/fixture/outputFileExtension/typescript/output.js
+++ b/packages/relay/transform/tests/fixture/outputFileExtension/typescript/output.js
@@ -1,0 +1,4 @@
+import __FooFragment from "__generated__/FooFragment.graphql.ts";
+import __FooQuery from "__generated__/FooQuery.graphql.ts";
+const myFragment = __FooFragment;
+useQuery(__FooQuery);

--- a/packages/remove-console/package.json
+++ b/packages/remove-console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-remove-console",
-  "version": "1.5.93",
+  "version": "1.5.94",
   "description": "SWC plugin for https://www.npmjs.com/package/babel-plugin-remove-console",
   "main": "swc_plugin_remove_console.wasm",
   "scripts": {

--- a/packages/remove-console/transform/Cargo.toml
+++ b/packages/remove-console/transform/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "remove_console"
 repository = "https://github.com/swc-project/plugins.git"
-version = "0.7.0"
+version = "0.8.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-styled-components",
-  "version": "1.5.93",
+  "version": "1.5.94",
   "description": "SWC plugin for styled-components",
   "main": "swc_plugin_styled_components.wasm",
   "scripts": {

--- a/packages/styled-components/transform/Cargo.toml
+++ b/packages/styled-components/transform/Cargo.toml
@@ -6,7 +6,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 license = "Apache-2.0"
 name = "styled_components"
 repository = "https://github.com/swc-project/plugins.git"
-version = "0.78.0"
+version = "0.79.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/packages/styled-jsx/package.json
+++ b/packages/styled-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-styled-jsx",
-  "version": "1.5.93",
+  "version": "1.5.94",
   "description": "SWC plugin for styled-jsx",
   "main": "swc_plugin_styled_jsx.wasm",
   "scripts": {

--- a/packages/styled-jsx/transform/Cargo.toml
+++ b/packages/styled-jsx/transform/Cargo.toml
@@ -4,7 +4,7 @@ description = "AST transforms visitor for styled-jsx"
 edition = "2021"
 license = "Apache-2.0"
 name = "styled_jsx"
-version = "0.55.0"
+version = "0.56.0"
 
 [features]
 custom_transform = ["swc_common/concurrent"]

--- a/packages/swc-magic/package.json
+++ b/packages/swc-magic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-swc-magic",
-  "version": "1.5.93",
+  "version": "1.5.94",
   "description": "SWC plugin for swc-magic",
   "main": "swc_plugin_swc_magic.wasm",
   "scripts": {

--- a/packages/swc-magic/transform/Cargo.toml
+++ b/packages/swc-magic/transform/Cargo.toml
@@ -4,7 +4,7 @@ description = "AST transforms visitor for swc-magic"
 edition = "2021"
 license = "Apache-2.0"
 name = "swc_magic"
-version = "0.1.0"
+version = "0.2.0"
 
 [dependencies]
 serde = { version = "1.0.189", features = ["derive"] }

--- a/packages/transform-imports/package.json
+++ b/packages/transform-imports/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-transform-imports",
-  "version": "1.5.93",
+  "version": "1.5.94",
   "description": "SWC plugin for https://www.npmjs.com/package/babel-plugin-transform-imports",
   "main": "swc_plugin_transform_imports.wasm",
   "scripts": {

--- a/packages/transform-imports/transform/Cargo.toml
+++ b/packages/transform-imports/transform/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "modularize_imports"
 repository = "https://github.com/swc-project/plugins.git"
-version = "0.51.0"
+version = "0.52.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
# Description

## Feature

In this PR we add `outputFileExtension` parameter in the config that can be:
- `ts`
- `js`
- `undefined`

When it's undefined we do the same behaviour as now which is controlled by `language` parameter
When it's configured we use the `outputFileExtension` parameter to specify which extension to use in the transpiled path import 

Example of usage: 
```typescript
 [
          '@swc/plugin-relay',
          {
            rootDir: __dirname,
            artifactDirectory: './src/relay/__generated__',
            eagerEsModules: true,
            outputFileExtension: 'js'
          },
],
```

## Initial issue

We are migrating from `babel` to `swc` and currently our babel plugin 

The output in dist are javascript esm and instead of having this

```javascript
import __stuffFragment1 from "../../../relay/__generated__/stuffFragment.graphql";
import { graphql } from "react-relay";
export const stuffFragment = __stuffFragment1;
```
we have this:
```javascript
import __stuffFragment1 from "../../../relay/__generated__/stuffFragment.graphql.ts";
import { graphql } from "react-relay";
export const stuffFragment = __stuffFragment1;
```
Basically it add `.ts` at the end but our files are javascript transpiled files

- I know it's due to default fallback to ts language: https://github.com/swc-project/plugins/blob/91fabf814285011eede6e80712da8ad7da1ae7ec/packages/relay/src/lib.rs#L42
- I know by default ts language add `.ts` at the end: https://github.com/swc-project/plugins/blob/91fabf814285011eede6e80712da8ad7da1ae7ec/packages/relay/transform/src/lib.rs#L165

Is it a configuration issue on our side or a plugin issue that by default transpilation import path should not have extensions ? If it's a configuration issue sorry in advance I thought the inputs were the same as the babel plugin

If we consider it as a bug I'll obviously fix this PR and update test, otherwise I'll close it and change the config on my side


Swc config:
```javascript
const config = {
  jsc: {
    baseUrl: 'src',
    parser: {
      syntax: 'typescript',
      tsx: true,
    },
    target: 'esnext',
    paths: {
      '@xxx/*': ['*'],
    },
    experimental: {
      plugins: [
        [
          '@swc/plugin-relay',
          {
            rootDir: __dirname,
            artifactDirectory: './src/relay/__generated__',
            eagerEsModules: true,
          },
        ],
      ],
    },
  },
  test: '(.ts|.tsx|.js|.jsx)',
};
```

previous babel config for relay:
```javascript
  plugins: [
    [
      'relay',
      {
        artifactDirectory: './src/relay/__generated__',
      },
    ],
```

Note: We cannot put `javascript` language type as our input files are `typescript`

found by @narajaon 