### PR TITLE
feat(loadable-components): Transpile `lazy` and signatures configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1948,18 +1948,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.201"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "780f1cebed1629e4753a1a38a3c72d30b97ec044f0aef68cb26650a3c5cf363c"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.201"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e405930b9796f1c00bee880d03fc7e0bb4b9a11afc776885ffe84320da2865"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2950,6 +2950,7 @@ version = "0.18.4"
 dependencies = [
  "once_cell",
  "regex",
+ "serde",
  "serde_json",
  "swc_common",
  "swc_core",

--- a/packages/loadable-components/Cargo.toml
+++ b/packages/loadable-components/Cargo.toml
@@ -18,6 +18,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 once_cell = "1.19.0"
 regex = "1.10.4"
+serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.117"
 swc_common = { version = "0.34.3", features = ["concurrent"] }
 swc_core = { version = "0.96.0", features = [

--- a/packages/loadable-components/README.tmpl.md
+++ b/packages/loadable-components/README.tmpl.md
@@ -6,4 +6,19 @@
 ["loadable-components", {}]
 ```
 
+Sometimes you need to wrap loadable with your own custom logic. There are many use cases for it, from injecting telemetry to hiding external libraries behind facade.
+By default `loadable-components` are configured to transform dynamic imports used only inside loadable helpers, but can be configured to instrument any other function of your choice.
+```json
+["loadable-components", { "signatures": [
+    {
+        "from": "myLoadableWrapper",
+        "name": "default" 
+    },
+    {
+        "from": "myLoadableWrapper",
+        "name": "lazy" 
+    }]
+}]
+```
+
 ${CHANGELOG}

--- a/packages/loadable-components/tests/fixture.rs
+++ b/packages/loadable-components/tests/fixture.rs
@@ -1,15 +1,55 @@
 use std::path::PathBuf;
 
 use swc_core::ecma::{transforms::testing::test_fixture, visit::as_folder};
-use swc_plugin_loadable_components::loadable_transform;
+use swc_plugin_loadable_components::{loadable_transform, Signature};
 
-#[testing::fixture("tests/fixture/**/input.js")]
-fn fixture(input: PathBuf) {
+#[testing::fixture("tests/fixture/aggressive import/**/input.js")]
+#[testing::fixture("tests/fixture/lazy/**/input.js")]
+#[testing::fixture("tests/fixture/loadable.lib/**/input.js")]
+#[testing::fixture("tests/fixture/magic comments/**/input.js")]
+#[testing::fixture("tests/fixture/simple import/**/input.js")]
+fn fixture_default_signatures(input: PathBuf) {
     let output = input.parent().unwrap().join("output.js");
 
     test_fixture(
         Default::default(),
-        &|t| as_folder(loadable_transform(t.comments.clone())),
+        &|t| {
+            as_folder(loadable_transform(
+                t.comments.clone(),
+                vec![Signature::default(), Signature::default_lazy()],
+            ))
+        },
+        &input,
+        &output,
+        Default::default(),
+    );
+}
+
+#[testing::fixture("tests/fixture/signatures/**/input.js")]
+fn fixture_custom_signatures(input: PathBuf) {
+    let output = input.parent().unwrap().join("output.js");
+
+    test_fixture(
+        Default::default(),
+        &|t| {
+            as_folder(loadable_transform(
+                t.comments.clone(),
+                vec![
+                    Signature {
+                        name: "lazy".into(),
+                        from: "my-custom-package".into(),
+                    },
+                    Signature {
+                        name: "custom".into(),
+                        from: "my-custom-package".into(),
+                    },
+                    Signature {
+                        name: "default".into(),
+                        from: "my-custom-package".into(),
+                    },
+                ],
+            ))
+        },
         &input,
         &output,
         Default::default(),

--- a/packages/loadable-components/tests/fixture/aggressive import/should work with destructuration/input.js
+++ b/packages/loadable-components/tests/fixture/aggressive import/should work with destructuration/input.js
@@ -1,1 +1,2 @@
+import loadable from "@loadable/component";
 loadable(({ foo }) => import(/* webpackChunkName: "Pages" */ `./${foo}`));

--- a/packages/loadable-components/tests/fixture/aggressive import/should work with destructuration/output.js
+++ b/packages/loadable-components/tests/fixture/aggressive import/should work with destructuration/output.js
@@ -1,3 +1,4 @@
+import loadable from "@loadable/component";
 loadable({
     resolved: {},
     chunkName ({ foo }) {

--- a/packages/loadable-components/tests/fixture/aggressive import/with webpackChunkName/should keep it/input.js
+++ b/packages/loadable-components/tests/fixture/aggressive import/with webpackChunkName/should keep it/input.js
@@ -1,3 +1,4 @@
+import loadable from "@loadable/component";
 loadable(
   (props) =>
     import(/* webpackChunkName: "pages/[request]" */ `./pages/${props.path}`),

--- a/packages/loadable-components/tests/fixture/aggressive import/with webpackChunkName/should keep it/output.js
+++ b/packages/loadable-components/tests/fixture/aggressive import/with webpackChunkName/should keep it/output.js
@@ -1,3 +1,4 @@
+import loadable from "@loadable/component";
 loadable({
     resolved: {},
     chunkName (props) {

--- a/packages/loadable-components/tests/fixture/aggressive import/with webpackChunkName/should replace it/input.js
+++ b/packages/loadable-components/tests/fixture/aggressive import/with webpackChunkName/should replace it/input.js
@@ -1,1 +1,2 @@
+import loadable from "@loadable/component";
 loadable((props) => import(/* webpackChunkName: "Pages" */ `./${props.foo}`));

--- a/packages/loadable-components/tests/fixture/aggressive import/with webpackChunkName/should replace it/output.js
+++ b/packages/loadable-components/tests/fixture/aggressive import/with webpackChunkName/should replace it/output.js
@@ -1,3 +1,4 @@
+import loadable from "@loadable/component";
 loadable({
     resolved: {},
     chunkName (props) {

--- a/packages/loadable-components/tests/fixture/aggressive import/without webpackChunkName/should support complex request/input.js
+++ b/packages/loadable-components/tests/fixture/aggressive import/without webpackChunkName/should support complex request/input.js
@@ -1,1 +1,2 @@
+import loadable from "@loadable/component";
 loadable((props) => import(`./dir/${props.foo}/test`));

--- a/packages/loadable-components/tests/fixture/aggressive import/without webpackChunkName/should support complex request/output.js
+++ b/packages/loadable-components/tests/fixture/aggressive import/without webpackChunkName/should support complex request/output.js
@@ -1,3 +1,4 @@
+import loadable from "@loadable/component";
 loadable({
     resolved: {},
     chunkName (props) {

--- a/packages/loadable-components/tests/fixture/aggressive import/without webpackChunkName/should support destructuring/input.js
+++ b/packages/loadable-components/tests/fixture/aggressive import/without webpackChunkName/should support destructuring/input.js
@@ -1,1 +1,2 @@
+import loadable from "@loadable/component";
 loadable(({ foo }) => import(`./dir/${foo}/test`));

--- a/packages/loadable-components/tests/fixture/aggressive import/without webpackChunkName/should support destructuring/output.js
+++ b/packages/loadable-components/tests/fixture/aggressive import/without webpackChunkName/should support destructuring/output.js
@@ -1,3 +1,4 @@
+import loadable from "@loadable/component";
 loadable({
     resolved: {},
     chunkName ({ foo }) {

--- a/packages/loadable-components/tests/fixture/aggressive import/without webpackChunkName/should support simple request/input.js
+++ b/packages/loadable-components/tests/fixture/aggressive import/without webpackChunkName/should support simple request/input.js
@@ -1,1 +1,2 @@
+import loadable from "@loadable/component";
 loadable((props) => import(`./${props.foo}`));

--- a/packages/loadable-components/tests/fixture/aggressive import/without webpackChunkName/should support simple request/output.js
+++ b/packages/loadable-components/tests/fixture/aggressive import/without webpackChunkName/should support simple request/output.js
@@ -1,3 +1,4 @@
+import loadable from "@loadable/component";
 loadable({
     resolved: {},
     chunkName (props) {

--- a/packages/loadable-components/tests/fixture/lazy/should be transpiled too/input.js
+++ b/packages/loadable-components/tests/fixture/lazy/should be transpiled too/input.js
@@ -1,0 +1,3 @@
+import { lazy } from "@loadable/component";
+
+lazy(() => import("./ModA"));

--- a/packages/loadable-components/tests/fixture/lazy/should be transpiled too/output.js
+++ b/packages/loadable-components/tests/fixture/lazy/should be transpiled too/output.js
@@ -1,8 +1,9 @@
-import loadable from "@loadable/component";
-loadable({
+import { lazy } from "@loadable/component";
+
+lazy({
     resolved: {},
     chunkName () {
-        return `ModA`.replace(/[^a-zA-Z0-9_!§$()=\\-^°]+/g, "-");
+        return "ModA";
     },
     isReady (props) {
         const key = this.resolve(props);
@@ -14,7 +15,7 @@ loadable({
         }
         return false;
     },
-    importAsync: ()=>import(/*webpackChunkName: "ModA"*/ `./ModA`),
+    importAsync: ()=>import(/*webpackChunkName: "ModA"*/ "./ModA"),
     requireAsync (props) {
         const key = this.resolve(props);
         this.resolved[key] = false;
@@ -32,8 +33,8 @@ loadable({
     },
     resolve () {
         if (require.resolveWeak) {
-            return require.resolveWeak(`./ModA`);
+            return require.resolveWeak("./ModA");
         }
-        return eval('require.resolve')(`./ModA`);
+        return eval('require.resolve')("./ModA");
     }
 });

--- a/packages/loadable-components/tests/fixture/lazy/should not work without imported/input.js
+++ b/packages/loadable-components/tests/fixture/lazy/should not work without imported/input.js
@@ -1,0 +1,3 @@
+import { lazy } from "react";
+
+lazy(() => import("./ModA"));

--- a/packages/loadable-components/tests/fixture/lazy/should not work without imported/output.js
+++ b/packages/loadable-components/tests/fixture/lazy/should not work without imported/output.js
@@ -1,0 +1,3 @@
+import { lazy } from "react";
+
+lazy(() => import("./ModA"));

--- a/packages/loadable-components/tests/fixture/lazy/should work with renamed specifier/input.js
+++ b/packages/loadable-components/tests/fixture/lazy/should work with renamed specifier/input.js
@@ -1,0 +1,3 @@
+import { lazy as renamedLazy } from "@loadable/component";
+
+renamedLazy(() => import("./ModA"));

--- a/packages/loadable-components/tests/fixture/lazy/should work with renamed specifier/output.js
+++ b/packages/loadable-components/tests/fixture/lazy/should work with renamed specifier/output.js
@@ -1,8 +1,9 @@
-import loadable from "@loadable/component";
-loadable({
+import { lazy as renamedLazy } from "@loadable/component";
+
+renamedLazy({
     resolved: {},
     chunkName () {
-        return `ModA`.replace(/[^a-zA-Z0-9_!§$()=\\-^°]+/g, "-");
+        return "ModA";
     },
     isReady (props) {
         const key = this.resolve(props);
@@ -14,7 +15,7 @@ loadable({
         }
         return false;
     },
-    importAsync: ()=>import(/*webpackChunkName: "ModA"*/ `./ModA`),
+    importAsync: ()=>import(/*webpackChunkName: "ModA"*/ "./ModA"),
     requireAsync (props) {
         const key = this.resolve(props);
         this.resolved[key] = false;
@@ -32,8 +33,8 @@ loadable({
     },
     resolve () {
         if (require.resolveWeak) {
-            return require.resolveWeak(`./ModA`);
+            return require.resolveWeak("./ModA");
         }
-        return eval('require.resolve')(`./ModA`);
+        return eval('require.resolve')("./ModA");
     }
 });

--- a/packages/loadable-components/tests/fixture/loadable.lib/should be transpiled too/input.js
+++ b/packages/loadable-components/tests/fixture/loadable.lib/should be transpiled too/input.js
@@ -1,1 +1,2 @@
+import loadable from "@loadable/component";
 loadable.lib(() => import("moment"));

--- a/packages/loadable-components/tests/fixture/loadable.lib/should be transpiled too/output.js
+++ b/packages/loadable-components/tests/fixture/loadable.lib/should be transpiled too/output.js
@@ -1,3 +1,4 @@
+import loadable from "@loadable/component";
 loadable.lib({
     resolved: {},
     chunkName () {

--- a/packages/loadable-components/tests/fixture/signatures/should not transpile unconfigured/input.js
+++ b/packages/loadable-components/tests/fixture/signatures/should not transpile unconfigured/input.js
@@ -1,0 +1,3 @@
+import { lazy } from "other-package";
+
+lazy(() => import("./ModA"));

--- a/packages/loadable-components/tests/fixture/signatures/should not transpile unconfigured/output.js
+++ b/packages/loadable-components/tests/fixture/signatures/should not transpile unconfigured/output.js
@@ -1,0 +1,3 @@
+import { lazy } from "other-package";
+
+lazy(() => import("./ModA"));

--- a/packages/loadable-components/tests/fixture/signatures/should transpile configured custom default/input.js
+++ b/packages/loadable-components/tests/fixture/signatures/should transpile configured custom default/input.js
@@ -1,0 +1,3 @@
+import custom from "my-custom-package";
+
+custom(() => import("./ModA"));

--- a/packages/loadable-components/tests/fixture/signatures/should transpile configured custom default/output.js
+++ b/packages/loadable-components/tests/fixture/signatures/should transpile configured custom default/output.js
@@ -1,8 +1,9 @@
-import loadable from "@loadable/component";
-loadable({
+import custom from "my-custom-package";
+
+custom({
     resolved: {},
     chunkName () {
-        return `ModA`.replace(/[^a-zA-Z0-9_!§$()=\\-^°]+/g, "-");
+        return "ModA";
     },
     isReady (props) {
         const key = this.resolve(props);
@@ -14,7 +15,7 @@ loadable({
         }
         return false;
     },
-    importAsync: ()=>import(/*webpackChunkName: "ModA"*/ `./ModA`),
+    importAsync: ()=>import(/*webpackChunkName: "ModA"*/ "./ModA"),
     requireAsync (props) {
         const key = this.resolve(props);
         this.resolved[key] = false;
@@ -32,8 +33,8 @@ loadable({
     },
     resolve () {
         if (require.resolveWeak) {
-            return require.resolveWeak(`./ModA`);
+            return require.resolveWeak("./ModA");
         }
-        return eval('require.resolve')(`./ModA`);
+        return eval('require.resolve')("./ModA");
     }
 });

--- a/packages/loadable-components/tests/fixture/signatures/should transpile configured custom/input.js
+++ b/packages/loadable-components/tests/fixture/signatures/should transpile configured custom/input.js
@@ -1,0 +1,3 @@
+import { custom } from "my-custom-package";
+
+custom(() => import("./ModA"));

--- a/packages/loadable-components/tests/fixture/signatures/should transpile configured custom/output.js
+++ b/packages/loadable-components/tests/fixture/signatures/should transpile configured custom/output.js
@@ -1,8 +1,9 @@
-import loadable from "@loadable/component";
-loadable({
+import { custom } from "my-custom-package";
+
+custom({
     resolved: {},
     chunkName () {
-        return `ModA`.replace(/[^a-zA-Z0-9_!§$()=\\-^°]+/g, "-");
+        return "ModA";
     },
     isReady (props) {
         const key = this.resolve(props);
@@ -14,7 +15,7 @@ loadable({
         }
         return false;
     },
-    importAsync: ()=>import(/*webpackChunkName: "ModA"*/ `./ModA`),
+    importAsync: ()=>import(/*webpackChunkName: "ModA"*/ "./ModA"),
     requireAsync (props) {
         const key = this.resolve(props);
         this.resolved[key] = false;
@@ -32,8 +33,8 @@ loadable({
     },
     resolve () {
         if (require.resolveWeak) {
-            return require.resolveWeak(`./ModA`);
+            return require.resolveWeak("./ModA");
         }
-        return eval('require.resolve')(`./ModA`);
+        return eval('require.resolve')("./ModA");
     }
 });

--- a/packages/loadable-components/tests/fixture/signatures/should transpile configured/input.js
+++ b/packages/loadable-components/tests/fixture/signatures/should transpile configured/input.js
@@ -1,0 +1,3 @@
+import { lazy } from "my-custom-package";
+
+lazy(() => import("./ModA"));

--- a/packages/loadable-components/tests/fixture/signatures/should transpile configured/output.js
+++ b/packages/loadable-components/tests/fixture/signatures/should transpile configured/output.js
@@ -1,8 +1,9 @@
-import loadable from "@loadable/component";
-loadable({
+import { lazy } from "my-custom-package";
+
+lazy({
     resolved: {},
     chunkName () {
-        return `ModA`.replace(/[^a-zA-Z0-9_!§$()=\\-^°]+/g, "-");
+        return "ModA";
     },
     isReady (props) {
         const key = this.resolve(props);
@@ -14,7 +15,7 @@ loadable({
         }
         return false;
     },
-    importAsync: ()=>import(/*webpackChunkName: "ModA"*/ `./ModA`),
+    importAsync: ()=>import(/*webpackChunkName: "ModA"*/ "./ModA"),
     requireAsync (props) {
         const key = this.resolve(props);
         this.resolved[key] = false;
@@ -32,8 +33,8 @@ loadable({
     },
     resolve () {
         if (require.resolveWeak) {
-            return require.resolveWeak(`./ModA`);
+            return require.resolveWeak("./ModA");
         }
-        return eval('require.resolve')(`./ModA`);
+        return eval('require.resolve')("./ModA");
     }
 });

--- a/packages/loadable-components/tests/fixture/simple import/in a complex promise/should work/input.js
+++ b/packages/loadable-components/tests/fixture/simple import/in a complex promise/should work/input.js
@@ -1,1 +1,2 @@
+import loadable from "@loadable/component";
 loadable(() => timeout(import("./ModA"), 2000));

--- a/packages/loadable-components/tests/fixture/simple import/in a complex promise/should work/output.js
+++ b/packages/loadable-components/tests/fixture/simple import/in a complex promise/should work/output.js
@@ -1,3 +1,4 @@
+import loadable from "@loadable/component";
 loadable({
     resolved: {},
     chunkName () {

--- a/packages/loadable-components/tests/fixture/simple import/should transform path into chunk-friendly name/input.js
+++ b/packages/loadable-components/tests/fixture/simple import/should transform path into chunk-friendly name/input.js
@@ -1,1 +1,2 @@
+import loadable from "@loadable/component";
 loadable(() => import("../foo/bar"));

--- a/packages/loadable-components/tests/fixture/simple import/should transform path into chunk-friendly name/output.js
+++ b/packages/loadable-components/tests/fixture/simple import/should transform path into chunk-friendly name/output.js
@@ -1,3 +1,4 @@
+import loadable from "@loadable/component";
 loadable({
     resolved: {},
     chunkName () {

--- a/packages/loadable-components/tests/fixture/simple import/should work with mul in name/input.js
+++ b/packages/loadable-components/tests/fixture/simple import/should work with mul in name/input.js
@@ -1,1 +1,2 @@
+import loadable from "@loadable/component";
 loadable(() => import(`./foo*`));

--- a/packages/loadable-components/tests/fixture/simple import/should work with mul in name/output.js
+++ b/packages/loadable-components/tests/fixture/simple import/should work with mul in name/output.js
@@ -1,3 +1,4 @@
+import loadable from "@loadable/component";
 loadable({
     resolved: {},
     chunkName () {

--- a/packages/loadable-components/tests/fixture/simple import/should work with plus concatenation/input.js
+++ b/packages/loadable-components/tests/fixture/simple import/should work with plus concatenation/input.js
@@ -1,1 +1,2 @@
+import loadable from "@loadable/component";
 loadable(() => import("./Mod" + "A"));

--- a/packages/loadable-components/tests/fixture/simple import/should work with plus concatenation/output.js
+++ b/packages/loadable-components/tests/fixture/simple import/should work with plus concatenation/output.js
@@ -1,3 +1,4 @@
+import loadable from "@loadable/component";
 loadable({
     resolved: {},
     chunkName () {

--- a/packages/loadable-components/tests/fixture/simple import/should work with template literal/input.js
+++ b/packages/loadable-components/tests/fixture/simple import/should work with template literal/input.js
@@ -1,1 +1,2 @@
+import loadable from "@loadable/component";
 loadable(() => import(`./ModA`));

--- a/packages/loadable-components/tests/fixture/simple import/with webpackChunkName comment/should add it/input.js
+++ b/packages/loadable-components/tests/fixture/simple import/with webpackChunkName comment/should add it/input.js
@@ -1,1 +1,2 @@
+import loadable from "@loadable/component";
 loadable(() => import("./ModA"));

--- a/packages/loadable-components/tests/fixture/simple import/with webpackChunkName comment/should add it/output.js
+++ b/packages/loadable-components/tests/fixture/simple import/with webpackChunkName comment/should add it/output.js
@@ -1,3 +1,4 @@
+import loadable from "@loadable/component";
 loadable({
     resolved: {},
     chunkName () {

--- a/packages/loadable-components/tests/fixture/simple import/with webpackChunkName comment/should use it even if comment is separated by ,/input.js
+++ b/packages/loadable-components/tests/fixture/simple import/with webpackChunkName comment/should use it even if comment is separated by ,/input.js
@@ -1,3 +1,4 @@
+import loadable from "@loadable/component";
 loadable(
   () =>
     import(/* webpackPrefetch: true, webpackChunkName: "ChunkA" */ "./ModA"),

--- a/packages/loadable-components/tests/fixture/simple import/with webpackChunkName comment/should use it even if comment is separated by ,/output.js
+++ b/packages/loadable-components/tests/fixture/simple import/with webpackChunkName comment/should use it even if comment is separated by ,/output.js
@@ -1,3 +1,4 @@
+import loadable from "@loadable/component";
 loadable({
     resolved: {},
     chunkName () {

--- a/packages/loadable-components/tests/fixture/simple import/with webpackChunkName comment/should use it even if quote is single/input.js
+++ b/packages/loadable-components/tests/fixture/simple import/with webpackChunkName comment/should use it even if quote is single/input.js
@@ -1,1 +1,3 @@
+import loadable from "@loadable/component";
+
 loadable(() => import(/* webpackChunkName: 'ChunkA' */ ""));

--- a/packages/loadable-components/tests/fixture/simple import/with webpackChunkName comment/should use it even if quote is single/output.js
+++ b/packages/loadable-components/tests/fixture/simple import/with webpackChunkName comment/should use it even if quote is single/output.js
@@ -1,3 +1,5 @@
+import loadable from "@loadable/component";
+
 loadable({
     resolved: {},
     chunkName () {

--- a/packages/loadable-components/tests/fixture/simple import/with webpackChunkName comment/should use it/input.js
+++ b/packages/loadable-components/tests/fixture/simple import/with webpackChunkName comment/should use it/input.js
@@ -1,1 +1,2 @@
+import loadable from "@loadable/component";
 loadable(() => import(/* webpackChunkName: "ChunkA" */ "./ModA"));

--- a/packages/loadable-components/tests/fixture/simple import/with webpackChunkName comment/should use it/output.js
+++ b/packages/loadable-components/tests/fixture/simple import/with webpackChunkName comment/should use it/output.js
@@ -1,3 +1,4 @@
+import loadable from "@loadable/component";
 loadable({
     resolved: {},
     chunkName () {


### PR DESCRIPTION
closes #241

This pull request brings behavior closer to babel plugin:
1. Add ability to transpile `lazy` from `@loadable/component` without hacks
2. Add ability to configure signatures. [babel plugin doc](https://github.com/gregberge/loadable-components/commit/edaf30c2ca385ef446ee1cbcad0e0e04cab61edf)

**BREAKING CHANGE:**

Before this changes plugin detected loadable only by `loadable` keyword.
After you should to configure `signatures` if you are using imports non from `@loadable/component`.
For example: 
```
["loadable-components", { "signatures": [
    {
        "from": "myLoadableWrapper",
        "name": "default" 
    },
    {
        "from": "myLoadableWrapper",
        "name": "lazy" 
    }]
}]
```
