### PR TITLE
fix(emotion): Fix panic on function name identifier being `None`

### DIFF
--- a/.changeset/tidy-baboons-allow.md
+++ b/.changeset/tidy-baboons-allow.md
@@ -1,5 +1,0 @@
----
-"@swc/plugin-emotion": patch
----
-
-Fix panic when trying to unwrap None on setting the context for a function name

--- a/.changeset/tidy-baboons-allow.md
+++ b/.changeset/tidy-baboons-allow.md
@@ -1,0 +1,5 @@
+---
+"@swc/plugin-emotion": patch
+---
+
+Fix panic when trying to unwrap None on setting the context for a function name

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2887,7 +2887,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_emotion"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/packages/emotion/CHANGELOG.md
+++ b/packages/emotion/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @swc/plugin-emotion
 
+## 2.5.115
+
+### Patch Changes
+
+- 906b5dd: Fix panic when trying to unwrap None on setting the context for a function name
+
 ## 2.5.114
 
 ### Patch Changes

--- a/packages/emotion/Cargo.toml
+++ b/packages/emotion/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "swc_plugin_emotion"
 publish = false
-version = "0.18.0"
+version = "0.18.1"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/packages/emotion/package.json
+++ b/packages/emotion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-emotion",
-  "version": "2.5.114",
+  "version": "2.5.115",
   "description": "SWC plugin for emotion css-in-js library",
   "main": "swc_plugin_emotion.wasm",
   "scripts": {

--- a/packages/emotion/transform/src/lib.rs
+++ b/packages/emotion/transform/src/lib.rs
@@ -445,12 +445,14 @@ impl<C: Comments> Fold for EmotionTransformer<C> {
         if let Pat::Ident(i) = &dec.name {
             self.current_context = Some(i.id.as_ref().to_owned());
         }
+
         // If we encounter a named function expression
-        if let Expr::Fn(f) = *dec.init.clone().unwrap() {
+        if let Some(Expr::Fn(f)) = dec.init.clone().map(|e| *e) {
             if let Some(i) = &f.ident {
                 self.current_context = Some(i.sym.as_ref().to_owned());
             }
         }
+
         dec.fold_children_with(self)
     }
 


### PR DESCRIPTION
Follow up to #245 

Fixes this panic by ensuring that there is something to unwrap:
```
thread '<unnamed>' panicked at 'called `Option::unwrap()` on a `None` value', /home/runner/work/plugins/plugins/packages/emotion/transform/src/lib.rs:449:48
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread '<unnamed>' panicked at /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/swc-0.270.26/src/plugin.rs:162:14:
failed to invoke plugin: failed to invoke plugin on 'Some("/Users/alexmiller/dev/app/node_modules/jest-runner/build/index.js")'

Caused by:
    0: failed to invoke `@swc/plugin-emotion` as js transform plugin at @swc/plugin-emotion
    1: RuntimeError: unreachable

Stack backtrace:
   0: _napi_register_module_v1
   1: _wasmer_vm_imported_memory32_atomic_notify
   2: _napi_register_module_v1
   3: _napi_register_module_v1
   4: _napi_register_module_v1
   5: _napi_register_module_v1
   6: _napi_register_module_v1
```