### PR TITLE
docs(loadable-components): fix misleading plugin config in `.swcrc`

### DIFF
--- a/packages/loadable-components/README.md
+++ b/packages/loadable-components/README.md
@@ -1,16 +1,10 @@
 # loadable-components
 
 ## Config
-If you use the .swcrc :
-```json
-["@swc/plugin-loadable-components", {}]
-```
 
-If you use the json config:
 ```json
 ["loadable-components", {}]
 ```
-
 
 # @swc/plugin-loadable-components
 

--- a/packages/loadable-components/README.md.tmpl
+++ b/packages/loadable-components/README.md.tmpl
@@ -2,6 +2,12 @@
 
 ## Config
 
+If you use the `.swcrc` :
+```json
+["@swc/plugin-loadable-components", {}]
+```
+
+If you use the js config:
 ```json
 ["loadable-components", {}]
 ```


### PR DESCRIPTION
## Why?

The README.md gives us a line that doesn't work in the .swcrc.
This is just a little PR to avoid people wasting time reading this config