### PR TITLE
feat(transform-imports): Support all kinds of imports/exports

### DIFF
--- a/.changeset/thick-apricots-punch.md
+++ b/.changeset/thick-apricots-punch.md
@@ -1,0 +1,5 @@
+---
+"@swc/plugin-transform-imports": patch
+---
+
+Add support for default and namespace imports/exports

--- a/packages/transform-imports/transform/src/lib.rs
+++ b/packages/transform-imports/transform/src/lib.rs
@@ -185,6 +185,21 @@ impl<'a> Rewriter<'a> {
                         with: None,
                     });
                 }
+                ExportSpecifier::Namespace(ns_spec) => {
+                    let name_str = match &ns_spec.name {
+                        ModuleExportName::Ident(x) => x.as_ref(),
+                        ModuleExportName::Str(x) => x.value.as_ref(),
+                    };
+                    let new_path = self.new_path(Some(name_str));
+                    let specifier = ExportSpecifier::Namespace(ns_spec.clone());
+                    out.push(NamedExport {
+                        specifiers: vec![specifier],
+                        src: Some(Box::new(Str::from(new_path.as_ref()))),
+                        span: old_decl.span,
+                        type_only: false,
+                        with: None,
+                    });
+                }
                 _ => {
                     if self.config.prevent_full_import {
                         panic!(

--- a/packages/transform-imports/transform/src/lib.rs
+++ b/packages/transform-imports/transform/src/lib.rs
@@ -185,7 +185,7 @@ impl<'a> Rewriter<'a> {
                         with: None,
                     });
                 }
-                ExportSpecifier::Namespace(ns_spec) => {
+                ExportSpecifier::Namespace(ns_spec) if !self.config.prevent_full_import => {
                     let name_str = match &ns_spec.name {
                         ModuleExportName::Ident(x) => x.as_ref(),
                         ModuleExportName::Str(x) => x.value.as_ref(),
@@ -253,7 +253,7 @@ impl<'a> Rewriter<'a> {
                         phase: Default::default(),
                     });
                 }
-                ImportSpecifier::Namespace(ns_spec) => {
+                ImportSpecifier::Namespace(ns_spec) if !self.config.prevent_full_import => {
                     let name_str = ns_spec.local.as_ref();
                     let new_path = self.new_path(Some(name_str));
                     let specifier = ImportSpecifier::Namespace(ns_spec.clone());
@@ -266,7 +266,7 @@ impl<'a> Rewriter<'a> {
                         phase: Default::default(),
                     });
                 }
-                ImportSpecifier::Default(def_spec) => {
+                ImportSpecifier::Default(def_spec) if !self.config.prevent_full_import => {
                     let name_str = def_spec.local.as_ref();
                     let new_path = self.new_path(Some(name_str));
                     let specifier = ImportSpecifier::Default(def_spec.clone());

--- a/packages/transform-imports/transform/src/lib.rs
+++ b/packages/transform-imports/transform/src/lib.rs
@@ -253,6 +253,19 @@ impl<'a> Rewriter<'a> {
                         phase: Default::default(),
                     });
                 }
+                ImportSpecifier::Namespace(ns_spec) => {
+                    let name_str = ns_spec.local.as_ref();
+                    let new_path = self.new_path(Some(name_str));
+                    let specifier = ImportSpecifier::Namespace(ns_spec.clone());
+                    out.push(ImportDecl {
+                        specifiers: vec![specifier],
+                        src: Box::new(Str::from(new_path.as_ref())),
+                        span: old_decl.span,
+                        type_only: false,
+                        with: None,
+                        phase: Default::default(),
+                    });
+                }
                 _ => {
                     if self.config.prevent_full_import {
                         panic!(

--- a/packages/transform-imports/transform/src/lib.rs
+++ b/packages/transform-imports/transform/src/lib.rs
@@ -266,6 +266,19 @@ impl<'a> Rewriter<'a> {
                         phase: Default::default(),
                     });
                 }
+                ImportSpecifier::Default(def_spec) => {
+                    let name_str = def_spec.local.as_ref();
+                    let new_path = self.new_path(Some(name_str));
+                    let specifier = ImportSpecifier::Default(def_spec.clone());
+                    out.push(ImportDecl {
+                        specifiers: vec![specifier],
+                        src: Box::new(Str::from(new_path.as_ref())),
+                        span: old_decl.span,
+                        type_only: false,
+                        with: None,
+                        phase: Default::default(),
+                    });
+                }
                 _ => {
                     if self.config.prevent_full_import {
                         panic!(

--- a/packages/transform-imports/transform/tests/fixture.rs
+++ b/packages/transform-imports/transform/tests/fixture.rs
@@ -78,6 +78,14 @@ fn modularize_imports_fixture(input: PathBuf) {
                             skip_default_conversion: true,
                         },
                     ),
+                    (
+                        "my-(module-namespace)".to_string(),
+                        PackageConfig {
+                            transform: "transformed-{{matches.[1]}}".into(),
+                            prevent_full_import: false,
+                            skip_default_conversion: true,
+                        },
+                    ),
                 ]
                 .into_iter()
                 .collect(),

--- a/packages/transform-imports/transform/tests/fixture.rs
+++ b/packages/transform-imports/transform/tests/fixture.rs
@@ -79,7 +79,7 @@ fn modularize_imports_fixture(input: PathBuf) {
                         },
                     ),
                     (
-                        "my-(module-namespace)".to_string(),
+                        "my-(module-namespace|default)".to_string(),
                         PackageConfig {
                             transform: "transformed-{{matches.[1]}}".into(),
                             prevent_full_import: false,

--- a/packages/transform-imports/transform/tests/fixture.rs
+++ b/packages/transform-imports/transform/tests/fixture.rs
@@ -79,7 +79,7 @@ fn modularize_imports_fixture(input: PathBuf) {
                         },
                     ),
                     (
-                        "my-(module-namespace|default)".to_string(),
+                        "my-(module-namespace|default|mixed-(named|star))".to_string(),
                         PackageConfig {
                             transform: "transformed-{{matches.[1]}}".into(),
                             prevent_full_import: false,

--- a/packages/transform-imports/transform/tests/fixture/default/input.js
+++ b/packages/transform-imports/transform/tests/fixture/default/input.js
@@ -1,0 +1,1 @@
+import defaultExport from "my-default";

--- a/packages/transform-imports/transform/tests/fixture/default/output.js
+++ b/packages/transform-imports/transform/tests/fixture/default/output.js
@@ -1,0 +1,1 @@
+import defaultExport from "transformed-default";

--- a/packages/transform-imports/transform/tests/fixture/mixed-default/input.js
+++ b/packages/transform-imports/transform/tests/fixture/mixed-default/input.js
@@ -1,0 +1,2 @@
+import defaultExport, { someNamedExport } from "my-mixed-named";
+import otherDefaultExport, * as starExport from "my-mixed-star";

--- a/packages/transform-imports/transform/tests/fixture/mixed-default/output.js
+++ b/packages/transform-imports/transform/tests/fixture/mixed-default/output.js
@@ -1,0 +1,4 @@
+import defaultExport from "transformed-mixed-named";
+import { someNamedExport } from "transformed-mixed-named";
+import otherDefaultExport from "transformed-mixed-star";
+import * as starExport from "transformed-mixed-star";

--- a/packages/transform-imports/transform/tests/fixture/namespace-export/input.js
+++ b/packages/transform-imports/transform/tests/fixture/namespace-export/input.js
@@ -1,0 +1,1 @@
+export * as someModule from "my-module-namespace";

--- a/packages/transform-imports/transform/tests/fixture/namespace-export/output.js
+++ b/packages/transform-imports/transform/tests/fixture/namespace-export/output.js
@@ -1,0 +1,1 @@
+export * as someModule from "transformed-module-namespace";

--- a/packages/transform-imports/transform/tests/fixture/namespace/input.js
+++ b/packages/transform-imports/transform/tests/fixture/namespace/input.js
@@ -1,0 +1,1 @@
+import * as someModule from "my-module-namespace";

--- a/packages/transform-imports/transform/tests/fixture/namespace/output.js
+++ b/packages/transform-imports/transform/tests/fixture/namespace/output.js
@@ -1,0 +1,1 @@
+import * as someModule from "transformed-module-namespace";


### PR DESCRIPTION
Closes https://github.com/swc-project/plugins/issues/323

This pull request adds support for namespace exports, and default and namespace imports, which were previously not supported by the plugin.