### PR TITLE
feat(prefresh): Add `@swc/plugin-prefresh`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2987,6 +2987,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "swc_plugin_prefresh"
+version = "0.1.0"
+dependencies = [
+ "serde_json",
+ "swc_common",
+ "swc_core",
+ "swc_prefresh",
+]
+
+[[package]]
 name = "swc_plugin_proxy"
 version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3118,6 +3128,22 @@ dependencies = [
  "swc_ecma_visit",
  "swc_plugin_macro",
  "tracing",
+]
+
+[[package]]
+name = "swc_prefresh"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "swc_atoms",
+ "swc_common",
+ "swc_core",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
+ "swc_ecma_transforms_base",
+ "swc_ecma_transforms_testing",
+ "swc_ecma_visit",
+ "testing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
   "packages/swc-confidential",
   "packages/swc-magic",
   "packages/transform-imports",
+  "packages/prefresh",
 ]
 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Plugins for SWC, written in Rust
 
-#### Currently Available
+#### Currently Available:
 
 - [`emotion`](packages/emotion)
 - [`jest`](packages/jest)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Plugins for SWC, written in Rust
 
-#### Currently Available:
+#### Currently Available
 
 - [`emotion`](packages/emotion)
 - [`jest`](packages/jest)
@@ -16,3 +16,4 @@ Plugins for SWC, written in Rust
 - [`swc-confidential`](packages/swc-confidential) for hiding sensitive strings in your code.
 - [`swc-magic`](packages/swc-magic) for building high-performance frameworks.
 - [`transform-imports`](packages/transform-imports)
+- [`prefresh`](packages/prefresh) for preact refresh transformation.

--- a/cspell.json
+++ b/cspell.json
@@ -6,6 +6,7 @@
     "lightningcss",
     "quasis",
     "rustc",
-    "swcrc"
+    "swcrc",
+    "prefresh"
   ]
 }

--- a/packages/prefresh/.gitignore
+++ b/packages/prefresh/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/packages/prefresh/.npmignore
+++ b/packages/prefresh/.npmignore
@@ -1,0 +1,2 @@
+transform/
+tests/

--- a/packages/prefresh/CHANGELOG.md
+++ b/packages/prefresh/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @swc/plugin-prefresh

--- a/packages/prefresh/Cargo.toml
+++ b/packages/prefresh/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+
+description = "SWC plugin for preact refresh."
+
+
+authors      = { workspace = true }
+edition      = { workspace = true }
+homepage     = { workspace = true }
+license      = { workspace = true }
+name         = "swc_plugin_prefresh"
+publish      = false
+repository   = { workspace = true }
+rust-version = { workspace = true }
+version      = "0.1.0"
+
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+serde_json = "1.0.117"
+swc_common = { version = "0.34.3" }
+swc_core   = { version = "0.96.0", features = ["ecma_plugin_transform"] }
+
+swc_prefresh = { path = "./transform" }

--- a/packages/prefresh/README.md
+++ b/packages/prefresh/README.md
@@ -1,0 +1,37 @@
+# @swc/plugin-prefresh
+
+The SWC implementation of the [prefresh babel plugin](https://github.com/preactjs/prefresh/tree/main/packages/babel).
+
+## Usage
+
+Prefresh babel plugin is a forked equivalent of the react-refresh babel plugin difference being that we need a way to memoize createContext between HMR.
+
+And SWC has built-in React Refresh transformation, therefore, this plugin only implements the `createContext` processing part and need to be used with `jsc.transform.react.refresh`.
+
+.swcrc:
+
+```json
+{
+  "jsc": {
+    "experimental": {
+      "plugins": [
+        [
+          "@swc/plugin-prefresh", // enable prefresh specific transformation
+          {
+            "library": ["preact-like-framework"] // the customizable preact name, default is `["preact", "preact/compat", "react"]`
+          }
+        ]
+      ]
+    },
+    "parser": {
+      "jsx": true
+    },
+    "transform": {
+      "react": {
+        "development": true,
+        "refresh": true, // enable react refresh transformation
+      }
+    }
+  }
+}
+```

--- a/packages/prefresh/README.md
+++ b/packages/prefresh/README.md
@@ -16,9 +16,11 @@ And SWC has built-in React Refresh transformation, therefore, this plugin only i
     "experimental": {
       "plugins": [
         [
-          "@swc/plugin-prefresh", // enable prefresh specific transformation
+          // enable prefresh specific transformation
+          "@swc/plugin-prefresh",
           {
-            "library": ["preact-like-framework"] // the customizable preact name, default is `["preact", "preact/compat", "react"]`
+            // the customizable preact name, default is `["preact", "preact/compat", "react"]`
+            "library": ["preact-like-framework"]
           }
         ]
       ]

--- a/packages/prefresh/README.tmpl.md
+++ b/packages/prefresh/README.tmpl.md
@@ -16,9 +16,11 @@ And SWC has built-in React Refresh transformation, therefore, this plugin only i
     "experimental": {
       "plugins": [
         [
-          "@swc/plugin-prefresh", // enable prefresh specific transformation
+          // enable prefresh specific transformation
+          "@swc/plugin-prefresh",
           {
-            "library": ["preact-like-framework"] // the customizable preact name, default is `["preact", "preact/compat", "react"]`
+            // the customizable preact name, default is `["preact", "preact/compat", "react"]`
+            "library": ["preact-like-framework"]
           }
         ]
       ]

--- a/packages/prefresh/README.tmpl.md
+++ b/packages/prefresh/README.tmpl.md
@@ -1,0 +1,39 @@
+# @swc/plugin-prefresh
+
+The SWC implementation of the [prefresh babel plugin](https://github.com/preactjs/prefresh/tree/main/packages/babel).
+
+## Usage
+
+Prefresh babel plugin is a forked equivalent of the react-refresh babel plugin difference being that we need a way to memoize createContext between HMR.
+
+And SWC has built-in React Refresh transformation, therefore, this plugin only implements the `createContext` processing part and need to be used with `jsc.transform.react.refresh`.
+
+.swcrc:
+
+```json
+{
+  "jsc": {
+    "experimental": {
+      "plugins": [
+        [
+          "@swc/plugin-prefresh", // enable prefresh specific transformation
+          {
+            "library": ["preact-like-framework"] // the customizable preact name, default is `["preact", "preact/compat", "react"]`
+          }
+        ]
+      ]
+    },
+    "parser": {
+      "jsx": true
+    },
+    "transform": {
+      "react": {
+        "development": true,
+        "refresh": true, // enable react refresh transformation
+      }
+    }
+  }
+}
+```
+
+${CHANGELOG}

--- a/packages/prefresh/package.json
+++ b/packages/prefresh/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@swc/plugin-prefresh",
+  "version": "2.0.7",
+  "description": "SWC plugin for preact refresh",
+  "main": "swc_plugin_prefresh.wasm",
+  "scripts": {
+    "prepack": "cargo build --release -p swc_plugin_prefresh --target wasm32-wasi && cp ../../target/wasm32-wasi/release/swc_plugin_prefresh.wasm ."
+  },
+  "homepage": "https://swc.rs",
+  "repository": {
+    "type": "git",
+    "url": "+https://github.com/swc-project/plugins.git"
+  },
+  "bugs": {
+    "url": "https://github.com/swc-project/plugins/issues"
+  },
+  "author": "강동윤 <kdy1997.dev@gmail.com>",
+  "keywords": [],
+  "license": "Apache-2.0",
+  "preferUnplugged": true,
+  "dependencies": {
+    "@swc/counter": "^0.1.3"
+  }
+}

--- a/packages/prefresh/src/lib.rs
+++ b/packages/prefresh/src/lib.rs
@@ -1,0 +1,23 @@
+#![allow(clippy::not_unsafe_ptr_arg_deref)]
+
+use swc_common::{SourceMapper, Spanned};
+use swc_core::{
+    ecma::{ast::Program, visit::FoldWith},
+    plugin::{plugin_transform, proxies::TransformPluginProgramMetadata},
+};
+#[plugin_transform]
+fn swc_plugin(program: Program, data: TransformPluginProgramMetadata) -> Program {
+    let config = serde_json::from_str::<Option<swc_prefresh::PrefreshPluginConfig>>(
+        &data
+            .get_transform_plugin_config()
+            .expect("failed to get plugin config for prefresh plugin"),
+    )
+    .expect("invalid packages")
+    .unwrap_or_default();
+
+    let source_map = std::sync::Arc::new(data.source_map);
+    let pos = source_map.lookup_char_pos(program.span().lo);
+    let hash = format!("{:x}", pos.file.src_hash);
+
+    program.fold_with(&mut swc_prefresh::swc_prefresh(config, hash))
+}

--- a/packages/prefresh/transform/Cargo.toml
+++ b/packages/prefresh/transform/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+
+description = "AST Transforms for prefresh plugin"
+
+name = "swc_prefresh"
+
+authors      = { workspace = true }
+edition      = { workspace = true }
+homepage     = { workspace = true }
+license      = { workspace = true }
+repository   = { workspace = true }
+rust-version = { workspace = true }
+version      = "0.1.0"
+
+[dependencies]
+serde          = { version = "1", features = ["derive"] }
+swc_atoms      = "0.6.7"
+swc_common     = "0.34.3"
+swc_core       = { version = "0.96.0", features = ["ecma_quote"] }
+swc_ecma_ast   = "0.115.1"
+swc_ecma_visit = "0.101.0"
+
+[dev-dependencies]
+swc_ecma_parser             = "0.146.7"
+swc_ecma_transforms_base    = "0.140.1"
+swc_ecma_transforms_testing = "0.143.1"
+testing                     = "0.36.0"

--- a/packages/prefresh/transform/src/lib.rs
+++ b/packages/prefresh/transform/src/lib.rs
@@ -1,0 +1,289 @@
+use std::{
+    collections::{HashMap, HashSet},
+    hash::{DefaultHasher, Hasher},
+};
+
+use serde::Deserialize;
+use swc_atoms::Atom;
+use swc_common::DUMMY_SP;
+use swc_core::quote;
+use swc_ecma_ast::{
+    AssignExpr, Callee, ComputedPropName, Expr, ExprOrSpread, Function, Id, Ident, ImportDecl,
+    ImportSpecifier, Lit, MemberExpr, ModuleExportName, ObjectPatProp, Tpl, TplElement,
+    VarDeclarator,
+};
+use swc_ecma_visit::{as_folder, Fold, VisitMut, VisitMutWith};
+
+pub fn swc_prefresh(config: PrefreshPluginConfig, file_hash: String) -> impl Fold {
+    as_folder(PrefreshPlugin::new(config, file_hash))
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct PrefreshPluginConfig {
+    pub library: Option<Vec<String>>,
+}
+
+pub fn hash_string(s: &str) -> String {
+    let mut hasher = DefaultHasher::new();
+    hasher.write(s.as_bytes());
+    let hash_result = hasher.finish();
+    format!("{:x}", hash_result)
+}
+
+#[derive(Debug)]
+pub struct PrefreshPlugin {
+    config: PrefreshPluginConfig,
+    file_hash: String,
+    parent_key: String,
+    param_key: String,
+    counter: HashMap<String, usize>,
+    local: HashSet<Id>,
+    lib_local: HashSet<Id>,
+}
+
+impl PrefreshPlugin {
+    pub fn new(config: PrefreshPluginConfig, file_hash: String) -> Self {
+        Self {
+            config,
+            file_hash,
+            parent_key: Default::default(),
+            param_key: Default::default(),
+            counter: Default::default(),
+            local: Default::default(),
+            lib_local: Default::default(),
+        }
+    }
+}
+
+impl PrefreshPlugin {
+    fn is_from_lib(&self, mem: &MemberExpr) -> bool {
+        let Some(root) = mem.obj.as_ident() else {
+            return false;
+        };
+        if !self.lib_local.contains(&root.to_id()) {
+            return false;
+        }
+
+        // xxx["createContext"]
+        if mem.prop.is_computed() {
+            let Some(ComputedPropName { expr, .. }) = mem.prop.as_computed() else {
+                return false;
+            };
+            let Expr::Lit(Lit::Str(lit)) = expr.as_ref() else {
+                return false;
+            };
+            lit.value == "createContext"
+        } else {
+            // xxx.createContext
+            mem.prop
+                .as_ident()
+                .is_some_and(|id| id.sym == "createContext")
+        }
+    }
+}
+
+impl VisitMut for PrefreshPlugin {
+    fn visit_mut_import_decl(&mut self, import_decl: &mut ImportDecl) {
+        let import_from = import_decl.src.value.to_string();
+        let is_library = self
+            .config
+            .library
+            .as_ref()
+            .unwrap_or(&vec!["preact".into(), "react".into()])
+            .contains(&import_from);
+
+        if !is_library {
+            return;
+        }
+
+        for spec in &import_decl.specifiers {
+            match spec {
+                ImportSpecifier::Default(spec) => {
+                    self.lib_local.insert(spec.local.to_id());
+                }
+                ImportSpecifier::Named(spec) => {
+                    if let Some(imported) = &spec.imported {
+                        let name = match imported {
+                            ModuleExportName::Ident(ident) => &ident.sym,
+                            ModuleExportName::Str(s) => &s.value,
+                        };
+                        if name == "createContext" {
+                            self.local.insert(spec.local.to_id());
+                        }
+                    } else if spec.local.sym == "createContext" {
+                        self.local.insert(spec.local.to_id());
+                    }
+                }
+                ImportSpecifier::Namespace(spec) => {
+                    self.lib_local.insert(spec.local.to_id());
+                }
+            }
+        }
+    }
+
+    fn visit_mut_expr(&mut self, expr: &mut Expr) {
+        let Expr::Call(call_expr) = expr else {
+            expr.visit_mut_children_with(self);
+            return;
+        };
+
+        let is_create_context = match &call_expr.callee {
+            Callee::Expr(expr) => match expr.as_ref() {
+                Expr::Ident(id) => self.local.contains(&id.to_id()),
+                Expr::Member(mem) => self.is_from_lib(mem),
+                _ => false,
+            },
+            _ => false,
+        };
+
+        if !is_create_context {
+            call_expr.visit_mut_children_with(self);
+            return;
+        }
+
+        let mut cnt = *self.counter.entry(self.parent_key.clone()).or_insert(0);
+        cnt += 1;
+        self.counter.insert(self.parent_key.clone(), cnt);
+
+        let context_id = format!(
+            "{}{}{}{}",
+            self.file_hash, self.parent_key, cnt, self.param_key
+        );
+
+        let parts = context_id.split("_PARAM").collect::<Vec<&str>>();
+        let exprs = parts
+            .iter()
+            .skip(1)
+            .map(|s| {
+                Box::new(Expr::Ident(Ident {
+                    span: DUMMY_SP,
+                    sym: Atom::from(s.replace('}', "").to_string()),
+                    optional: false,
+                }))
+            })
+            .collect::<Vec<_>>();
+
+        let mut quasis = vec![TplElement {
+            span: DUMMY_SP,
+            tail: false,
+            cooked: None,
+            raw: Atom::from(
+                parts
+                    .first()
+                    .expect("Should have at lease on part")
+                    .to_string(),
+            ),
+        }];
+        quasis.extend(
+            exprs
+                .iter()
+                .map(|_| TplElement {
+                    span: DUMMY_SP,
+                    tail: false,
+                    cooked: None,
+                    raw: Atom::from(""),
+                })
+                .collect::<Vec<_>>(),
+        );
+
+        let create_context_expr = call_expr
+            .callee
+            .as_expr()
+            .expect("Should convert callee to expr")
+            .as_ref()
+            .clone();
+        let ident_expr = Expr::Tpl(Tpl {
+            span: DUMMY_SP,
+            exprs,
+            quasis,
+        });
+
+        let replacement = if let Some(ExprOrSpread { expr, spread: None }) = call_expr.args.first()
+        {
+            quote!(
+              "Object.assign(($create_context[$ident] || ($create_context[$ident]=$create_context($value))), {__:$value})" as Expr,
+              create_context: Expr = create_context_expr,
+              ident: Expr = ident_expr,
+              value: Expr = expr.as_ref().clone()
+            )
+        } else {
+            quote!(
+              "($create_context[$ident] || ($create_context[$ident]=$create_context()))" as Expr,
+              create_context: Expr = create_context_expr,
+              ident: Expr = ident_expr,
+            )
+        };
+
+        *expr = replacement;
+    }
+
+    fn visit_mut_object_pat_prop(&mut self, obj_pat_prop: &mut ObjectPatProp) {
+        let key = obj_pat_prop
+            .as_key_value()
+            .and_then(|kv| kv.key.as_str())
+            .map(|s| s.value.to_string())
+            .unwrap_or_default();
+
+        if key.is_empty() {
+            obj_pat_prop.visit_mut_children_with(self);
+        } else {
+            let old_key = self.parent_key.clone();
+            self.parent_key = format!("__{key}");
+            obj_pat_prop.visit_mut_children_with(self);
+            self.parent_key = old_key;
+        }
+    }
+
+    fn visit_mut_var_declarator(&mut self, var_declarator_expr: &mut VarDeclarator) {
+        let key = var_declarator_expr
+            .name
+            .as_ident()
+            .map(|id| id.sym.to_string())
+            .unwrap_or_default();
+
+        if key.is_empty() {
+            var_declarator_expr.visit_mut_children_with(self);
+        } else {
+            let old_key = self.parent_key.clone();
+            self.parent_key = format!("${key}");
+            var_declarator_expr.visit_mut_children_with(self);
+            self.parent_key = old_key;
+        }
+    }
+
+    fn visit_mut_assign_expr(&mut self, assign_expr: &mut AssignExpr) {
+        let key = assign_expr
+            .left
+            .as_ident()
+            .map(|id| id.sym.to_string())
+            .unwrap_or_else(|| hash_string(&format!("{:?}", assign_expr.left))); // used getSource() in babel
+
+        if key.is_empty() {
+            assign_expr.visit_mut_children_with(self);
+        } else {
+            let old_key = self.parent_key.clone();
+            self.parent_key = format!("_{key}");
+            assign_expr.visit_mut_children_with(self);
+            self.parent_key = old_key;
+        }
+    }
+
+    fn visit_mut_function(&mut self, func: &mut Function) {
+        let key = func
+            .params
+            .iter()
+            .filter_map(|p| p.pat.as_ident().map(|id| id.sym.to_string()))
+            .collect::<Vec<String>>()
+            .join("_PARAM");
+
+        if key.is_empty() {
+            func.visit_mut_children_with(self);
+        } else {
+            let old_key = self.param_key.clone();
+            self.param_key = format!("__PARAM{key}");
+            func.visit_mut_children_with(self);
+            self.param_key = old_key;
+        }
+    }
+}

--- a/packages/prefresh/transform/src/lib.rs
+++ b/packages/prefresh/transform/src/lib.rs
@@ -239,7 +239,7 @@ impl VisitMut for PrefreshPlugin {
         let key = var_declarator_expr
             .name
             .as_ident()
-            .map(|id| id.sym.to_string())
+            .map(|id| id.sym.clone())
             .unwrap_or_default();
 
         if key.is_empty() {

--- a/packages/prefresh/transform/src/lib.rs
+++ b/packages/prefresh/transform/src/lib.rs
@@ -21,7 +21,8 @@ pub fn swc_prefresh(config: PrefreshPluginConfig, file_hash: String) -> impl Fol
 #[derive(Debug, Clone, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct PrefreshPluginConfig {
-    pub library: Option<Vec<String>>,
+    #[serde(default = "default_library")]
+    pub library: Vec<String>,
 }
 fn default_library() -> Vec<String> {
     vec!["preact".into(), "react".into()]

--- a/packages/prefresh/transform/src/lib.rs
+++ b/packages/prefresh/transform/src/lib.rs
@@ -23,7 +23,9 @@ pub fn swc_prefresh(config: PrefreshPluginConfig, file_hash: String) -> impl Fol
 pub struct PrefreshPluginConfig {
     pub library: Option<Vec<String>>,
 }
-
+fn default_library() -> Vec<String> {
+    vec!["preact".into(), "react".into()]
+}
 pub fn hash_string(s: &str) -> String {
     let mut hasher = DefaultHasher::new();
     hasher.write(s.as_bytes());

--- a/packages/prefresh/transform/tests/fixture.rs
+++ b/packages/prefresh/transform/tests/fixture.rs
@@ -1,0 +1,35 @@
+use std::path::PathBuf;
+
+use swc_common::{chain, Mark};
+use swc_ecma_transforms_base::resolver;
+use swc_ecma_transforms_testing::test_fixture;
+
+#[testing::fixture("tests/fixture/**/input.js")]
+fn fixture(input: PathBuf) {
+    let output = input
+        .parent()
+        .expect("should have parent directory")
+        .join("output.js");
+
+    test_fixture(
+        Default::default(),
+        &|_tr| {
+            chain!(
+                resolver(Mark::new(), Mark::new(), false),
+                swc_prefresh::swc_prefresh(
+                    swc_prefresh::PrefreshPluginConfig {
+                        library: Some(vec![
+                            "@custom/preact".to_string(),
+                            "preact".to_string(),
+                            "react".to_string()
+                        ]),
+                    },
+                    "__file_hash__".to_string(),
+                )
+            )
+        },
+        &input,
+        &output,
+        Default::default(),
+    );
+}

--- a/packages/prefresh/transform/tests/fixture.rs
+++ b/packages/prefresh/transform/tests/fixture.rs
@@ -18,11 +18,11 @@ fn fixture(input: PathBuf) {
                 resolver(Mark::new(), Mark::new(), false),
                 swc_prefresh::swc_prefresh(
                     swc_prefresh::PrefreshPluginConfig {
-                        library: Some(vec![
+                        library: vec![
                             "@custom/preact".to_string(),
                             "preact".to_string(),
                             "react".to_string()
-                        ]),
+                        ],
                     },
                     "__file_hash__".to_string(),
                 )

--- a/packages/prefresh/transform/tests/fixture/basic/input.js
+++ b/packages/prefresh/transform/tests/fixture/basic/input.js
@@ -1,0 +1,5 @@
+import { createContext } from 'preact';
+
+export function aaa() {
+  const context = createContext();
+}

--- a/packages/prefresh/transform/tests/fixture/basic/output.js
+++ b/packages/prefresh/transform/tests/fixture/basic/output.js
@@ -1,0 +1,4 @@
+import { createContext } from 'preact';
+export function aaa() {
+  const context = createContext[`__file_hash__$context1`] || (createContext[`__file_hash__$context1`] = createContext());
+}

--- a/packages/prefresh/transform/tests/fixture/import_custom_preact/input.js
+++ b/packages/prefresh/transform/tests/fixture/import_custom_preact/input.js
@@ -1,0 +1,5 @@
+import { createContext } from '@custom/preact';
+
+export function aaa() {
+  const context = createContext();
+}

--- a/packages/prefresh/transform/tests/fixture/import_custom_preact/output.js
+++ b/packages/prefresh/transform/tests/fixture/import_custom_preact/output.js
@@ -1,0 +1,4 @@
+import { createContext } from '@custom/preact';
+export function aaa() {
+  const context = createContext[`__file_hash__$context1`] || (createContext[`__file_hash__$context1`] = createContext());
+}

--- a/packages/prefresh/transform/tests/fixture/import_default/input.js
+++ b/packages/prefresh/transform/tests/fixture/import_default/input.js
@@ -1,0 +1,5 @@
+import pp from 'preact';
+
+export function aaa(a, b) {
+  const context = pp.createContext();
+}

--- a/packages/prefresh/transform/tests/fixture/import_default/output.js
+++ b/packages/prefresh/transform/tests/fixture/import_default/output.js
@@ -1,0 +1,4 @@
+import pp from 'preact';
+export function aaa(a, b) {
+  const context = pp.createContext[`__file_hash__$context1_${a}${b}`] || (pp.createContext[`__file_hash__$context1_${a}${b}`] = pp.createContext());
+}

--- a/packages/prefresh/transform/tests/fixture/import_lib_computed/input.js
+++ b/packages/prefresh/transform/tests/fixture/import_lib_computed/input.js
@@ -1,0 +1,5 @@
+import pp from 'preact';
+
+export function aaa(a, b) {
+  const context = pp["createContext"]();
+}

--- a/packages/prefresh/transform/tests/fixture/import_lib_computed/output.js
+++ b/packages/prefresh/transform/tests/fixture/import_lib_computed/output.js
@@ -1,0 +1,4 @@
+import pp from 'preact';
+export function aaa(a, b) {
+  const context = pp["createContext"][`__file_hash__$context1_${a}${b}`] || (pp["createContext"][`__file_hash__$context1_${a}${b}`] = pp["createContext"]());
+}

--- a/packages/prefresh/transform/tests/fixture/import_named/input.js
+++ b/packages/prefresh/transform/tests/fixture/import_named/input.js
@@ -1,0 +1,5 @@
+import { createContext as cc } from 'preact';
+
+export function aaa() {
+  const context = cc();
+}

--- a/packages/prefresh/transform/tests/fixture/import_named/output.js
+++ b/packages/prefresh/transform/tests/fixture/import_named/output.js
@@ -1,0 +1,4 @@
+import { createContext as cc } from 'preact';
+export function aaa() {
+  const context = cc[`__file_hash__$context1`] || (cc[`__file_hash__$context1`] = cc());
+}

--- a/packages/prefresh/transform/tests/fixture/import_namespace/input.js
+++ b/packages/prefresh/transform/tests/fixture/import_namespace/input.js
@@ -1,0 +1,5 @@
+import * as pp from 'preact';
+
+export function aaa() {
+  const context = pp.createContext();
+}

--- a/packages/prefresh/transform/tests/fixture/import_namespace/output.js
+++ b/packages/prefresh/transform/tests/fixture/import_namespace/output.js
@@ -1,0 +1,4 @@
+import * as pp from 'preact';
+export function aaa() {
+  const context = pp.createContext[`__file_hash__$context1`] || (pp.createContext[`__file_hash__$context1`] = pp.createContext());
+}

--- a/packages/prefresh/transform/tests/fixture/local/input.js
+++ b/packages/prefresh/transform/tests/fixture/local/input.js
@@ -1,0 +1,9 @@
+import { createContext } from "preact";
+export function aaa() {
+  function createContext() { }
+  const context = createContext();
+}
+
+export function bbb() {
+  const context = createContext();
+}

--- a/packages/prefresh/transform/tests/fixture/local/output.js
+++ b/packages/prefresh/transform/tests/fixture/local/output.js
@@ -1,0 +1,8 @@
+import { createContext } from "preact";
+export function aaa() {
+  function createContext() { }
+  const context = createContext();
+}
+export function bbb() {
+  const context = createContext[`__file_hash__$context1`] || (createContext[`__file_hash__$context1`] = createContext());
+}

--- a/packages/prefresh/transform/tests/fixture/multiple/input.js
+++ b/packages/prefresh/transform/tests/fixture/multiple/input.js
@@ -1,0 +1,14 @@
+import { createContext as cc } from 'preact';
+import * as ns from 'preact';
+import df from 'preact';
+
+export function aaa(a, b) {
+  cc({});
+  ns.createContext();
+  df.createContext(b);
+  return function bbb(a, b, c) {
+    cc({});
+    ns.createContext();
+    df.createContext(b);
+  }
+}

--- a/packages/prefresh/transform/tests/fixture/multiple/output.js
+++ b/packages/prefresh/transform/tests/fixture/multiple/output.js
@@ -1,0 +1,21 @@
+import { createContext as cc } from 'preact';
+import * as ns from 'preact';
+import df from 'preact';
+export function aaa(a, b) {
+  Object.assign(cc[`__file_hash__1_${a}${b}`] || (cc[`__file_hash__1_${a}${b}`] = cc({})), {
+    __: {}
+  });
+  ns.createContext[`__file_hash__2_${a}${b}`] || (ns.createContext[`__file_hash__2_${a}${b}`] = ns.createContext());
+  Object.assign(df.createContext[`__file_hash__3_${a}${b}`] || (df.createContext[`__file_hash__3_${a}${b}`] = df.createContext(b)), {
+    __: b
+  });
+  return function bbb(a, b, c) {
+    Object.assign(cc[`__file_hash__4_${a}${b}${c}`] || (cc[`__file_hash__4_${a}${b}${c}`] = cc({})), {
+      __: {}
+    });
+    ns.createContext[`__file_hash__5_${a}${b}${c}`] || (ns.createContext[`__file_hash__5_${a}${b}${c}`] = ns.createContext());
+    Object.assign(df.createContext[`__file_hash__6_${a}${b}${c}`] || (df.createContext[`__file_hash__6_${a}${b}${c}`] = df.createContext(b)), {
+      __: b
+    });
+  };
+}

--- a/packages/prefresh/transform/tests/fixture/param/input.js
+++ b/packages/prefresh/transform/tests/fixture/param/input.js
@@ -1,0 +1,5 @@
+import { createContext } from 'preact';
+
+export function aaa(a, b) {
+  const context = createContext();
+}

--- a/packages/prefresh/transform/tests/fixture/param/output.js
+++ b/packages/prefresh/transform/tests/fixture/param/output.js
@@ -1,0 +1,4 @@
+import { createContext } from 'preact';
+export function aaa(a, b) {
+  const context = createContext[`__file_hash__$context1_${a}${b}`] || (createContext[`__file_hash__$context1_${a}${b}`] = createContext());
+}

--- a/packages/prefresh/transform/tests/fixture/value/input.js
+++ b/packages/prefresh/transform/tests/fixture/value/input.js
@@ -1,0 +1,5 @@
+import { createContext } from 'preact';
+
+export function aaa(a, b) {
+  const context = createContext({});
+}

--- a/packages/prefresh/transform/tests/fixture/value/output.js
+++ b/packages/prefresh/transform/tests/fixture/value/output.js
@@ -1,0 +1,6 @@
+import { createContext } from 'preact';
+export function aaa(a, b) {
+  const context = Object.assign(createContext[`__file_hash__$context1_${a}${b}`] || (createContext[`__file_hash__$context1_${a}${b}`] = createContext({})), {
+    __: {}
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,12 @@ importers:
         specifier: ^0.1.3
         version: 0.1.3
 
+  packages/prefresh:
+    dependencies:
+      '@swc/counter':
+        specifier: ^0.1.3
+        version: 0.1.3
+
   packages/react-remove-properties:
     dependencies:
       '@swc/counter':


### PR DESCRIPTION
Add `@swc/plugin-prefresh`, which is the SWC implementation of the [prefresh babel plugin](https://github.com/preactjs/prefresh/tree/main/packages/babel).

Prefresh babel plugin is a forked equivalent of the react-refresh babel plugin difference being that we need a way to memoize createContext between HMR.

And SWC has built-in React Refresh transformation, therefore, this plugin only implements the `createContext` processing part and need to be used with `jsc.transform.react.refresh`.

For example:

```json
{
  "jsc": {
    "experimental": {
      "plugins": [
        [
          // enable prefresh specific transformation
          "@swc/plugin-prefresh",
          {
            // the customizable preact name, default is `["preact", "preact/compat", "react"]`
            "library": ["preact-like-framework"]
          }
        ]
      ]
    },
    "parser": {
      "jsx": true
    },
    "transform": {
      "react": {
        "development": true,
        "refresh": true, // enable react refresh transformation
      }
    }
  }
}
```
