### PR TITLE
refactor: Make the plugins usable from custom SWC binary

### DIFF
--- a/.changeset/tasty-meals-flash.md
+++ b/.changeset/tasty-meals-flash.md
@@ -1,8 +1,0 @@
----
-"@swc/plugin-emotion": minor
-"@swc/plugin-styled-components": minor
-"@swc/plugin-styled-jsx": minor
-"@swc/plugin-transform-imports": minor
----
-
-Make it usable from custom Rust binaries

--- a/.changeset/tasty-meals-flash.md
+++ b/.changeset/tasty-meals-flash.md
@@ -1,0 +1,8 @@
+---
+"@swc/plugin-emotion": minor
+"@swc/plugin-styled-components": minor
+"@swc/plugin-styled-jsx": minor
+"@swc/plugin-transform-imports": minor
+---
+
+Make it usable from custom Rust binaries

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1335,7 +1335,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "modularize_imports"
-version = "0.71.0"
+version = "0.71.1"
 dependencies = [
  "convert_case",
  "handlebars",
@@ -2352,7 +2352,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "styled_components"
-version = "0.99.0"
+version = "0.99.1"
 dependencies = [
  "Inflector",
  "once_cell",
@@ -2373,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "styled_jsx"
-version = "0.76.0"
+version = "0.76.1"
 dependencies = [
  "anyhow",
  "lightningcss",
@@ -2997,7 +2997,7 @@ dependencies = [
 
 [[package]]
 name = "swc_emotion"
-version = "0.75.0"
+version = "0.75.1"
 dependencies = [
  "base64 0.22.1",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1335,7 +1335,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "modularize_imports"
-version = "0.71.1"
+version = "0.72.0"
 dependencies = [
  "convert_case",
  "handlebars",
@@ -2352,7 +2352,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "styled_components"
-version = "0.99.1"
+version = "0.100.0"
 dependencies = [
  "Inflector",
  "once_cell",
@@ -2373,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "styled_jsx"
-version = "0.76.1"
+version = "0.77.0"
 dependencies = [
  "anyhow",
  "lightningcss",
@@ -2997,7 +2997,7 @@ dependencies = [
 
 [[package]]
 name = "swc_emotion"
-version = "0.75.1"
+version = "0.76.0"
 dependencies = [
  "base64 0.22.1",
  "byteorder",

--- a/packages/emotion/CHANGELOG.md
+++ b/packages/emotion/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @swc/plugin-emotion
 
+## 8.4.0
+
+### Minor Changes
+
+- 728f208: Make it usable from custom Rust binaries
+
 ## 8.3.0
 
 ### Minor Changes

--- a/packages/emotion/README.md
+++ b/packages/emotion/README.md
@@ -34,6 +34,12 @@ Source code for plugin itself (not transforms) are copied from https://github.co
 
 # @swc/plugin-emotion
 
+## 8.4.0
+
+### Minor Changes
+
+- 728f208: Make it usable from custom Rust binaries
+
 ## 8.3.0
 
 ### Minor Changes

--- a/packages/emotion/package.json
+++ b/packages/emotion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-emotion",
-  "version": "8.3.0",
+  "version": "8.4.0",
   "description": "SWC plugin for emotion css-in-js library",
   "main": "swc_plugin_emotion.wasm",
   "scripts": {

--- a/packages/emotion/transform/Cargo.toml
+++ b/packages/emotion/transform/Cargo.toml
@@ -7,7 +7,7 @@ license      = { workspace = true }
 name         = "swc_emotion"
 repository   = { workspace = true }
 rust-version = { workspace = true }
-version      = "0.75.1"
+version      = "0.76.0"
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/packages/emotion/transform/Cargo.toml
+++ b/packages/emotion/transform/Cargo.toml
@@ -7,7 +7,7 @@ license      = { workspace = true }
 name         = "swc_emotion"
 repository   = { workspace = true }
 rust-version = { workspace = true }
-version      = "0.75.0"
+version      = "0.75.1"
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/packages/styled-components/CHANGELOG.md
+++ b/packages/styled-components/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @swc/plugin-styled-components
 
+## 6.4.0
+
+### Minor Changes
+
+- 728f208: Make it usable from custom Rust binaries
+
 ## 6.3.0
 
 ### Minor Changes

--- a/packages/styled-components/README.md
+++ b/packages/styled-components/README.md
@@ -28,6 +28,12 @@ Then update your `.swcrc` file like below:
 
 # @swc/plugin-styled-components
 
+## 6.4.0
+
+### Minor Changes
+
+- 728f208: Make it usable from custom Rust binaries
+
 ## 6.3.0
 
 ### Minor Changes

--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-styled-components",
-  "version": "6.3.0",
+  "version": "6.4.0",
   "description": "SWC plugin for styled-components",
   "main": "swc_plugin_styled_components.wasm",
   "scripts": {

--- a/packages/styled-components/transform/Cargo.toml
+++ b/packages/styled-components/transform/Cargo.toml
@@ -12,7 +12,7 @@ homepage     = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }
 rust-version = { workspace = true }
-version      = "0.99.0"
+version      = "0.99.1"
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/packages/styled-components/transform/Cargo.toml
+++ b/packages/styled-components/transform/Cargo.toml
@@ -12,7 +12,7 @@ homepage     = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }
 rust-version = { workspace = true }
-version      = "0.99.1"
+version      = "0.100.0"
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/packages/styled-jsx/CHANGELOG.md
+++ b/packages/styled-jsx/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @swc/plugin-styled-jsx
 
+## 6.4.0
+
+### Minor Changes
+
+- 728f208: Make it usable from custom Rust binaries
+
 ## 6.3.0
 
 ### Minor Changes

--- a/packages/styled-jsx/README.md
+++ b/packages/styled-jsx/README.md
@@ -2,6 +2,12 @@
 
 # @swc/plugin-styled-jsx
 
+## 6.4.0
+
+### Minor Changes
+
+- 728f208: Make it usable from custom Rust binaries
+
 ## 6.3.0
 
 ### Minor Changes

--- a/packages/styled-jsx/package.json
+++ b/packages/styled-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-styled-jsx",
-  "version": "6.3.0",
+  "version": "6.4.0",
   "description": "SWC plugin for styled-jsx",
   "main": "swc_plugin_styled_jsx.wasm",
   "scripts": {

--- a/packages/styled-jsx/transform/Cargo.toml
+++ b/packages/styled-jsx/transform/Cargo.toml
@@ -10,7 +10,7 @@ license      = { workspace = true }
 name         = "styled_jsx"
 repository   = { workspace = true }
 rust-version = { workspace = true }
-version      = "0.76.0"
+version      = "0.76.1"
 
 
 [features]

--- a/packages/styled-jsx/transform/Cargo.toml
+++ b/packages/styled-jsx/transform/Cargo.toml
@@ -10,7 +10,7 @@ license      = { workspace = true }
 name         = "styled_jsx"
 repository   = { workspace = true }
 rust-version = { workspace = true }
-version      = "0.76.1"
+version      = "0.77.0"
 
 
 [features]

--- a/packages/transform-imports/CHANGELOG.md
+++ b/packages/transform-imports/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @swc/plugin-transform-imports
 
+## 6.2.0
+
+### Minor Changes
+
+- 728f208: Make it usable from custom Rust binaries
+
 ## 6.1.0
 
 ### Minor Changes

--- a/packages/transform-imports/README.md
+++ b/packages/transform-imports/README.md
@@ -18,6 +18,12 @@
 
 # @swc/plugin-transform-imports
 
+## 6.2.0
+
+### Minor Changes
+
+- 728f208: Make it usable from custom Rust binaries
+
 ## 6.1.0
 
 ### Minor Changes

--- a/packages/transform-imports/package.json
+++ b/packages/transform-imports/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-transform-imports",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "SWC plugin for https://www.npmjs.com/package/babel-plugin-transform-imports",
   "main": "swc_plugin_transform_imports.wasm",
   "scripts": {

--- a/packages/transform-imports/transform/Cargo.toml
+++ b/packages/transform-imports/transform/Cargo.toml
@@ -11,7 +11,7 @@ homepage     = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }
 rust-version = { workspace = true }
-version      = "0.71.0"
+version      = "0.71.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/packages/transform-imports/transform/Cargo.toml
+++ b/packages/transform-imports/transform/Cargo.toml
@@ -11,7 +11,7 @@ homepage     = { workspace = true }
 license      = { workspace = true }
 repository   = { workspace = true }
 rust-version = { workspace = true }
-version      = "0.71.1"
+version      = "0.72.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
I made a mistake while working on the previous PR, and thus, I failed to update SWC plugins with https://github.com/vercel/next.js/pull/75275