### PR TITLE
fix(styled-components): Visit member expressions for display name

### DIFF
--- a/packages/styled-components/transform/tests/fixtures/add-display-names-with-member-expressions/code.js
+++ b/packages/styled-components/transform/tests/fixtures/add-display-names-with-member-expressions/code.js
@@ -1,0 +1,7 @@
+import styled from 'styled-components'
+
+const App = {};
+
+App.Foo = styled.div``;
+
+App.Foo.Bar = styled.div``

--- a/packages/styled-components/transform/tests/fixtures/add-display-names-with-member-expressions/config.json
+++ b/packages/styled-components/transform/tests/fixtures/add-display-names-with-member-expressions/config.json
@@ -1,0 +1,4 @@
+{
+    "fileName": true,
+    "displayName": true
+}

--- a/packages/styled-components/transform/tests/fixtures/add-display-names-with-member-expressions/output.js
+++ b/packages/styled-components/transform/tests/fixtures/add-display-names-with-member-expressions/output.js
@@ -1,0 +1,14 @@
+import styled from 'styled-components';
+const App = {};
+App.Foo = styled.div.withConfig({
+    displayName: "code__Foo",
+    componentId: "sc-11752c5e-0"
+})([
+    ``
+]);
+App.Foo.Bar = styled.div.withConfig({
+    displayName: "code__Bar",
+    componentId: "sc-11752c5e-1"
+})([
+    ``
+]);


### PR DESCRIPTION
Resolves #420. 

This matches how babel-plugin-styled-components does it. (see [getName.js](https://github.com/styled-components/babel-plugin-styled-components/blob/4e2eb388d9c90f2921c306c760657d059d01a518/src/utils/getName.js#L39-L42)).