### PR TITLE
fix(styled-components): Use PascalCase instead of ClassCase

### DIFF
--- a/packages/styled-components/transform/src/visitors/transpile_css_prop/transpile.rs
+++ b/packages/styled-components/transform/src/visitors/transpile_css_prop/transpile.rs
@@ -89,7 +89,7 @@ impl VisitMut for TranspileCssProp<'_> {
                     };
 
                     let name = get_name_ident(&elem.opening.name);
-                    let id_sym = name.sym.to_class_case();
+                    let id_sym = name.sym.to_pascal_case();
 
                     // Match the original plugin's behavior.
                     let id_sym = id_sym.trim_end_matches(char::is_numeric);


### PR DESCRIPTION
ClassCase will singularize the input (remove any trailing "s", e.g. "Icons" -> "Icon".) This doesn't match what babel-plugin-styled-components does.