### PR TITLE
feat(formatjs): Support hash encodings in id interpolation pattern

### DIFF
--- a/.changeset/tired-streets-grab.md
+++ b/.changeset/tired-streets-grab.md
@@ -1,0 +1,5 @@
+---
+"@swc/plugin-formatjs": minor
+---
+
+add support for hex and base64url digest encodings in idInterpolationPattern placeholders

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3312,6 +3312,7 @@ version = "4.0.0"
 dependencies = [
  "base64ct",
  "digest 0.10.7",
+ "hex",
  "once_cell",
  "pretty_assertions",
  "regex",

--- a/packages/formatjs/__tests__/wasm.test.ts
+++ b/packages/formatjs/__tests__/wasm.test.ts
@@ -224,4 +224,30 @@ describe("formatjs swc plugin", () => {
 
     expect(output).toMatch(/id: "zL\/jyT\"/);
   });
+
+  it("should be able to use different encodings in interpolation", async () => {
+    const input = `
+      import { FormattedMessage } from 'react-intl';
+
+      export function Greeting() {
+        return (
+          <FormattedMessage
+            defaultMessage="Hello, World!"
+            description="Greeting message"
+          />
+        );
+      }
+    `;
+
+    const hexOutput = await transformCode(input, {
+      idInterpolationPattern: "[sha512:contenthash:hex:9]",
+    });
+
+    const base64UrlOutput = await transformCode(input, {
+      idInterpolationPattern: "[sha512:contenthash:base64url:12]",
+    });
+
+    expect(hexOutput).toMatch(/id: "[0-9a-f]{9}"/);
+    expect(base64UrlOutput).toMatch(/id: "[a-zA-Z0-9-_]{12}"/);
+  });
 });

--- a/packages/formatjs/transform/Cargo.toml
+++ b/packages/formatjs/transform/Cargo.toml
@@ -16,6 +16,7 @@ custom_transform = []
 [dependencies]
 base64ct   = { workspace = true, features = ["alloc"] }
 digest     = { workspace = true }
+hex        = { workspace = true }
 once_cell  = { workspace = true }
 regex      = { workspace = true }
 serde      = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
FormatJs Babel plugin allows using any binary-to-text encoding supported by NodeJS Buffer. Currently, this includes "base64", "base64url", and "hex". See <https://nodejs.org/api/buffer.html#buffers-and-character-encodings>.

Add support for "hex" and "base64url" encodings. Use "hex" by default to match the behavior of the Babel plugin.

fixes #401