### PR TITLE
formatjs plugin - Serialize description objects

### DIFF
--- a/packages/formatjs/__tests__/wasm.test.ts
+++ b/packages/formatjs/__tests__/wasm.test.ts
@@ -204,4 +204,24 @@ describe("formatjs swc plugin", () => {
     expect(sha512output).toMatch(/id: "[a-zA-Z0-9]{6}"/);
     expect(sha1output).not.toMatch(sha512output);
   });
+
+  it("should be able to use object description", async () => {
+    const input = `
+      import { FormattedMessage } from 'react-intl';
+
+      export function Greeting() {
+        return (
+          <FormattedMessage
+            defaultMessage="Hello!"
+            description={{ text: "Greeting message" }}
+          />
+        );
+      }
+    `;
+
+    console.log(input);
+    const output = await transformCode(input);
+
+    expect(output).toMatch(/id: "zL\/jyT\"/);
+  });
 });

--- a/packages/formatjs/transform/src/lib.rs
+++ b/packages/formatjs/transform/src/lib.rs
@@ -570,6 +570,10 @@ fn evaluate_jsx_message_descriptor(
 
         let content = if let Some(MessageDescriptionValue::Str(description)) = &description {
             format!("{}#{}", default_message, description)
+        } else if let Some(MessageDescriptionValue::Obj(_)) = &description {
+            // When description is an object, stringify it for the hash calculation
+            let desc_json = serde_json::to_string(&description).unwrap_or_default();
+            format!("{}#{}", default_message, desc_json)
         } else {
             default_message.clone()
         };
@@ -610,6 +614,10 @@ fn evaluate_call_expr_message_descriptor(
 
         let content = if let Some(MessageDescriptionValue::Str(description)) = &description {
             format!("{}#{}", default_message, description)
+        } else if let Some(MessageDescriptionValue::Obj(_)) = &description {
+            // When description is an object, stringify it for the hash calculation
+            let desc_json = serde_json::to_string(&description).unwrap_or_default();
+            format!("{}#{}", default_message, desc_json)
         } else {
             default_message.clone()
         };


### PR DESCRIPTION
To bring parity with `ts-transformer` [implementation](https://github.com/formatjs/formatjs/blob/946a73c2f3bc51464298e40a85e8335e17304b3e/packages/ts-transformer/src/transform.ts#L415) and when the description is an object, stringify it 