### PR TITLE
fix(formatjs): sort description objects before serialization

### DIFF
--- a/.changeset/happy-hotels-complain.md
+++ b/.changeset/happy-hotels-complain.md
@@ -1,0 +1,5 @@
+---
+"@swc/plugin-formatjs": patch
+---
+
+fix(formatjs): Sort description objects before serialization

--- a/packages/formatjs/__tests__/wasm.test.ts
+++ b/packages/formatjs/__tests__/wasm.test.ts
@@ -225,6 +225,39 @@ describe("formatjs swc plugin", () => {
     expect(output).toMatch(/id: "zL\/jyT\"/);
   });
 
+  it("should generate same id even if order of keys is different in two description objects with same keys", async () => {
+    const input = `
+      import { FormattedMessage } from 'react-intl';
+
+      export function Greeting() {
+        return (
+          <FormattedMessage
+            defaultMessage="Hello!"
+            description={{ text: "Greeting message", image: "https://example.com/image.png" }}
+          />
+        );
+      }
+    `;
+
+    const input2 = `
+      import { FormattedMessage } from 'react-intl';
+
+      export function Greeting() {
+        return (
+          <FormattedMessage
+            defaultMessage="Hello!"
+            description={{ image: "https://example.com/image.png", text: "Greeting message" }}
+          />
+        );
+      }
+    `;
+
+    const output = await transformCode(input);
+    const output2 = await transformCode(input2);
+
+    expect(output).toMatch(output2);
+  });
+
   it("should be able to use different encodings in interpolation", async () => {
     const input = `
       import { FormattedMessage } from 'react-intl';


### PR DESCRIPTION
In my previous [PR](https://github.com/swc-project/plugins/pull/439) I missed the case that two description objects having the same keys but in a different order.
This will address that. Added a unit test to make sure it works.