### PR TITLE
Fix tests typo, add Cargo.toml to .npmignore

### DIFF
--- a/packages/emotion/.npmignore
+++ b/packages/emotion/.npmignore
@@ -1,2 +1,3 @@
+__tests__/
 transform/
-tests/
+Cargo.toml

--- a/packages/formatjs/.npmignore
+++ b/packages/formatjs/.npmignore
@@ -1,2 +1,3 @@
+__tests__/
 transform/
-tests/
+Cargo.toml

--- a/packages/jest/.npmignore
+++ b/packages/jest/.npmignore
@@ -1,2 +1,3 @@
+__tests__/
 transform/
-tests/
+Cargo.toml

--- a/packages/loadable-components/.npmignore
+++ b/packages/loadable-components/.npmignore
@@ -1,2 +1,3 @@
+__tests__/
 transform/
-tests/
+Cargo.toml

--- a/packages/noop/.npmignore
+++ b/packages/noop/.npmignore
@@ -1,2 +1,3 @@
+__tests__/
 transform/
-tests/
+Cargo.toml

--- a/packages/prefresh/.npmignore
+++ b/packages/prefresh/.npmignore
@@ -1,2 +1,3 @@
+__tests__/
 transform/
-tests/
+Cargo.toml

--- a/packages/react-remove-properties/.npmignore
+++ b/packages/react-remove-properties/.npmignore
@@ -1,2 +1,3 @@
+__tests__/
 transform/
-tests/
+Cargo.toml

--- a/packages/relay/.npmignore
+++ b/packages/relay/.npmignore
@@ -1,2 +1,3 @@
+__tests__/
 transform/
-tests/
+Cargo.toml

--- a/packages/remove-console/.npmignore
+++ b/packages/remove-console/.npmignore
@@ -1,2 +1,3 @@
+__tests__/
 transform/
-tests/
+Cargo.toml

--- a/packages/styled-components/.npmignore
+++ b/packages/styled-components/.npmignore
@@ -1,2 +1,3 @@
+__tests__/
 transform/
-tests/
+Cargo.toml

--- a/packages/styled-jsx/.npmignore
+++ b/packages/styled-jsx/.npmignore
@@ -1,2 +1,3 @@
+__tests__/
 transform/
-tests/
+Cargo.toml

--- a/packages/swc-confidential/.npmignore
+++ b/packages/swc-confidential/.npmignore
@@ -1,2 +1,3 @@
+__tests__/
 transform/
-tests/
+Cargo.toml

--- a/packages/swc-magic/.npmignore
+++ b/packages/swc-magic/.npmignore
@@ -1,2 +1,3 @@
+__tests__/
 transform/
-tests/
+Cargo.toml

--- a/packages/swc-sdk/.npmignore
+++ b/packages/swc-sdk/.npmignore
@@ -1,2 +1,3 @@
+__tests__/
 transform/
-tests/
+Cargo.toml

--- a/packages/transform-imports/.npmignore
+++ b/packages/transform-imports/.npmignore
@@ -1,2 +1,3 @@
+__tests__/
 transform/
-tests/
+Cargo.toml


### PR DESCRIPTION
I noticed that the test files are still included in the published npm package at, e.g. https://www.npmjs.com/package/@swc/plugin-relay?activeTab=code

I'm assuming that's a typo.

Additionally, I added Cargo.toml to the .npmignore to help avoid conflicts with multi-language projects since Cargo can read into node_modules, e.g. https://github.com/bazelbuild/rules_rust/issues/3425