### PR TITLE
fix(formatjs): Generate same id after React Compiler

### DIFF
--- a/.changeset/nine-kiwis-add.md
+++ b/.changeset/nine-kiwis-add.md
@@ -1,0 +1,5 @@
+---
+"@swc/plugin-formatjs": patch
+---
+
+Generate the same ID after React Compiler


### PR DESCRIPTION
In this PR we keep track of variable binding on declaration and assignments to get actual description values from.
The main motivator for this work is to support react compiler out of box and for it to support same id generation.

React compiler changes following code from:
```
export function Greeting() {
        return (
          <FormattedMessage
            defaultMessage="Hello {name}"
            description={{
              text: "Hello",
              img: "https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png",
            }}
            values={{
              name: value.value,
            }}
          />
        );
      }
```
to
```
export function Client(t0) {
        const $ = _c(3);
        const { value } = t0;
        let t1;
        if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
          t1 = {
            text: "Hello",
            img: "https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png",
          };
          $[0] = t1;
        } else {
          t1 = $[0];
        }
        let t2;
        if ($[1] !== value.value) {
          t2 = (
            <FormattedMessage
              defaultMessage="Hello {name}"
              description={t1}
              values={{ name: value.value }}
            />
          );
          $[1] = value.value;
          $[2] = t2;
        } else {
          t2 = $[2];
        }
        return t2;
      }
```

Added unit tests for both simple external variable declaration and also react compiler optimizations