### PR TITLE
fix(transform-imports): Transform side-effect imports

### DIFF
--- a/packages/transform-imports/__tests__/__snapshots__/wasm.test.ts.snap
+++ b/packages/transform-imports/__tests__/__snapshots__/wasm.test.ts.snap
@@ -63,7 +63,7 @@ export { default as Footer } from "my-library/components/App/Footer";
 `;
 
 exports[`Should load transform-imports wasm plugin correctly > Should transform side-effect-imports correctly 1`] = `
-"import './upload/upload.ts';
+"import "./upload/upload.js";
 import './scripts/scripts.model.js';
 "
 `;

--- a/packages/transform-imports/transform/src/lib.rs
+++ b/packages/transform-imports/transform/src/lib.rs
@@ -381,9 +381,18 @@ impl VisitMut for TransformImports<'_> {
         for item in module.body.take() {
             match item {
                 ModuleItem::ModuleDecl(ModuleDecl::Import(decl)) => {
-                    // Ignore side-effect only imports
                     if decl.specifiers.is_empty() {
-                        new_items.push(ModuleItem::ModuleDecl(ModuleDecl::Import(decl)));
+                        if let Some(rewriter) = self.should_rewrite(&decl.src.value) {
+                            let new_path = rewriter.new_path(None); 
+                            let new_decl = ImportDecl {
+                                src: Box::new(Str::from(new_path.as_ref())),
+                                specifiers: vec![],
+                                ..decl
+                            };
+                            new_items.push(ModuleItem::ModuleDecl(ModuleDecl::Import(new_decl)));
+                        } else {
+                            new_items.push(ModuleItem::ModuleDecl(ModuleDecl::Import(decl)));
+                        }
                         continue;
                     }
 

--- a/packages/transform-imports/transform/tests/fixture/side-effect-imports/output.js
+++ b/packages/transform-imports/transform/tests/fixture/side-effect-imports/output.js
@@ -1,2 +1,2 @@
-import './upload/upload.ts';
+import './upload/upload.js';
 import './scripts/scripts.model.js';


### PR DESCRIPTION
[Original issue](https://github.com/swc-project/plugins/issues/329): Imports with side effects were being incorrectly removed. The expected behavior is to retain the import and apply the transformation.

The current behavior causes issues when the code includes TypeScript side-effect imports. These are skipped by the plugin and remain untransformed, which leads to runtime failures in Node.js (since it cannot import .ts files directly).