### PR TITLE
Add @swc/plugin-transform-ns-imports

### DIFF
--- a/.changeset/cold-beds-tap.md
+++ b/.changeset/cold-beds-tap.md
@@ -1,0 +1,5 @@
+---
+"@swc/plugin-transform-ns-imports": patch
+---
+
+Init transform-ns-imports package

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3674,6 +3674,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "swc_plugin_transform_ns_imports"
+version = "0.19.4"
+dependencies = [
+ "serde_json",
+ "swc_common",
+ "swc_core",
+ "swc_ecma_ast",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
+ "swc_plugin_macro",
+ "tracing",
+ "transform_ns_imports",
+]
+
+[[package]]
 name = "swc_prefresh"
 version = "0.20.0"
 dependencies = [
@@ -4022,6 +4037,25 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "transform_ns_imports"
+version = "0.89.0"
+dependencies = [
+ "convert_case",
+ "handlebars",
+ "once_cell",
+ "regex",
+ "serde",
+ "swc_atoms",
+ "swc_cached",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
+ "swc_ecma_transforms_testing",
+ "swc_ecma_visit",
+ "testing",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -16,5 +16,6 @@ Plugins for SWC, written in Rust
 - [`swc-confidential`](packages/swc-confidential) for hiding sensitive strings in your code.
 - [`swc-magic`](packages/swc-magic) for building high-performance frameworks.
 - [`transform-imports`](packages/transform-imports)
+- [`transform-ns-imports`](packages/transform-ns-imports) for transforming namespace imports.
 - [`prefresh`](packages/prefresh) for preact refresh transformation.
 - [`formatjs`](packages/formatjs)

--- a/packages/transform-ns-imports/.idea/.gitignore
+++ b/packages/transform-ns-imports/.idea/.gitignore
@@ -1,0 +1,8 @@
+# 默认忽略的文件
+/shelf/
+/workspace.xml
+# 基于编辑器的 HTTP 客户端请求
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/packages/transform-ns-imports/.idea/CodeverseWorkspaceAppSettings.xml
+++ b/packages/transform-ns-imports/.idea/CodeverseWorkspaceAppSettings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="com.codeverse.userSettings.CodeverseWorkspaceAppSettingsState">
+    <option name="ckgOperationStatus" value="SUCCESS" />
+  </component>
+</project>

--- a/packages/transform-ns-imports/.idea/modules.xml
+++ b/packages/transform-ns-imports/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/transform-ns-imports.iml" filepath="$PROJECT_DIR$/.idea/transform-ns-imports.iml" />
+    </modules>
+  </component>
+</project>

--- a/packages/transform-ns-imports/.idea/transform-ns-imports.iml
+++ b/packages/transform-ns-imports/.idea/transform-ns-imports.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="EMPTY_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/transform/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/transform/tests" isTestSource="true" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/packages/transform-ns-imports/.idea/vcs.xml
+++ b/packages/transform-ns-imports/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/../.." vcs="Git" />
+  </component>
+</project>

--- a/packages/transform-ns-imports/.npmignore
+++ b/packages/transform-ns-imports/.npmignore
@@ -1,0 +1,3 @@
+__tests__/
+transform/
+Cargo.toml

--- a/packages/transform-ns-imports/CHANGELOG.md
+++ b/packages/transform-ns-imports/CHANGELOG.md
@@ -1,0 +1,2 @@
+# @swc/plugin-transform-ns-imports
+

--- a/packages/transform-ns-imports/Cargo.toml
+++ b/packages/transform-ns-imports/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+
+description = "SWC plugin for transform namsspace imports as proxy"
+
+
+authors      = { workspace = true }
+edition      = { workspace = true }
+homepage     = { workspace = true }
+license      = { workspace = true }
+name         = "swc_plugin_transform_ns_imports"
+publish      = false
+repository   = { workspace = true }
+rust-version = { workspace = true }
+version      = "0.19.4"
+
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+serde_json           = { workspace = true }
+swc_common           = { workspace = true, features = ["concurrent"] }
+swc_core             = { workspace = true, features = ["ecma_plugin_transform"] }
+swc_ecma_ast         = { workspace = true }
+swc_ecma_utils       = { workspace = true }
+swc_ecma_visit       = { workspace = true }
+swc_plugin_macro     = { workspace = true }
+tracing              = { workspace = true, features = ["release_max_level_off"] }
+transform_ns_imports = { path = "./transform" }

--- a/packages/transform-ns-imports/README.md
+++ b/packages/transform-ns-imports/README.md
@@ -1,0 +1,60 @@
+# transform-ns-imports
+
+The plugin for patch transform-imports plugin and
+provide transform namespace import syntax to proxy entry for dynamic ESM.
+
+
+## Configuration
+
+```json
+[
+  "transform-ns-imports",
+  {
+    "react-icon": {
+      "rewrite": "react-icon/proxy-import"
+    },
+    "react-component": {
+      "transform": "react-component/proxy-import"
+    }
+  }
+]
+```
+
+## Behavior
+
+Add it transform reexport from:
+
+```ts
+export * as someModule from "rewrite-module-namespace";
+```
+
+to:
+
+```ts
+export {default as someModule} from "rewrite-module-namespace/proxy-import";
+```
+
+and transform import from:
+
+```ts
+import * as test from 'rewrite-module-namespace'
+```
+
+to:
+
+```ts
+import test from "rewrite-module-namespace/proxy-import";
+```
+
+And you can create the proxy-import file content see like:
+
+```ts
+import {lazy} from 'react'
+
+const modules = {};
+export default new Proxy(modules, {
+    get(name) {
+        return lazy(() => import(`module/${name}`);
+    }
+})
+```

--- a/packages/transform-ns-imports/README.tmpl.md
+++ b/packages/transform-ns-imports/README.tmpl.md
@@ -1,0 +1,61 @@
+# transform-ns-imports
+
+The plugin for patch transform-imports plugin and
+provide transform namespace import syntax to proxy entry for dynamic ESM.
+
+## Configuration
+
+```json
+[
+  "transform-ns-imports",
+  {
+    "react-icon": {
+      "rewrite": "react-icon/proxy-import"
+    },
+    "react-component": {
+      "transform": "react-component/proxy-import"
+    }
+  }
+]
+```
+
+## Behavior
+
+Add it transform reexport from:
+
+```ts
+export * as someModule from "rewrite-module-namespace";
+```
+
+to:
+
+```ts
+export {default as someModule} from "rewrite-module-namespace/proxy-import";
+```
+
+and transform import from:
+
+```ts
+import * as test from 'rewrite-module-namespace'
+```
+
+to:
+
+```ts
+import test from "rewrite-module-namespace/proxy-import";
+```
+
+And you can create the proxy-import file content see like:
+
+```ts
+import {lazy} from 'react'
+
+const modules = {};
+export default new Proxy(modules, {
+    get(name) {
+        return lazy(() => import(`module/${name}`);
+    }
+})
+```
+
+${CHANGELOG}

--- a/packages/transform-ns-imports/__tests__/__snapshots__/wasm.test.ts.snap
+++ b/packages/transform-ns-imports/__tests__/__snapshots__/wasm.test.ts.snap
@@ -1,0 +1,11 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Should load transform-ns-imports wasm plugin correctly > Should transform rewrite-namespace correctly 1`] = `
+"import test from "rewrite-module-namespace/swc-proxy";
+"
+`;
+
+exports[`Should load transform-ns-imports wasm plugin correctly > Should transform rewrite-namespace-export correctly 1`] = `
+"export { default as someModule } from "rewrite-module-namespace/swc-proxy";
+"
+`;

--- a/packages/transform-ns-imports/__tests__/wasm.test.ts
+++ b/packages/transform-ns-imports/__tests__/wasm.test.ts
@@ -1,0 +1,82 @@
+import { expect, test, describe } from "vitest";
+import { transform } from "@swc/core";
+import path from "node:path";
+import url from "node:url";
+import fs from "node:fs/promises";
+
+const pluginName = "swc_plugin_transform_ns_imports.wasm";
+
+const transformCode = async (
+  code: string,
+  options: Record<string, unknown> = {
+    "rewrite-module-namespace": {
+      rewrite: "rewrite-module-namespace/swc-proxy",
+    },
+  },
+) => {
+  return transform(code, {
+    jsc: {
+      parser: {
+        syntax: "ecmascript",
+        jsx: true,
+      },
+      target: "es3",
+      experimental: {
+        plugins: [
+          [
+            path.join(
+              path.dirname(url.fileURLToPath(import.meta.url)),
+              "..",
+              pluginName,
+            ),
+            options,
+          ],
+        ],
+      },
+    },
+    filename: "test.js",
+  });
+};
+
+async function walkDir(
+  dir: URL,
+  callback: (
+    dir: string,
+    input: string,
+    config?: Record<string, unknown>,
+  ) => Promise<void>,
+) {
+  const dirs = await fs.readdir(dir);
+  const baseDir = url.fileURLToPath(dir);
+
+  for (const dir of dirs) {
+    const inputFilePath = path.join(baseDir, dir, "input.js");
+    const configPath = path.join(baseDir, dir, "config.json");
+
+    const config = await fs.readFile(configPath, "utf-8").then(
+      (json) => {
+        return JSON.parse(json);
+      },
+      (_) => undefined,
+    );
+
+    try {
+      const input = await fs.readFile(inputFilePath, "utf-8");
+      await callback(dir, input, config);
+    } catch (e) {
+      console.log(e);
+    }
+  }
+}
+
+describe("Should load transform-ns-imports wasm plugin correctly", async () => {
+  await walkDir(
+    new URL("../transform/tests/fixture", import.meta.url),
+    async (dir, input, config) => {
+      await test(`Should transform ${dir} correctly`, async () => {
+        const { code } = await transformCode(input, config);
+        expect(code).toMatchSnapshot();
+      });
+    },
+  );
+});

--- a/packages/transform-ns-imports/package.json
+++ b/packages/transform-ns-imports/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@swc/plugin-transform-ns-imports",
+  "version": "1.0.0",
+  "description": "SWC plugin for transform namespace imports to proxy",
+  "main": "swc_plugin_transform_ns_imports.wasm",
+  "scripts": {
+    "prepack": "pnpm run build",
+    "build": "cargo build --release -p swc_plugin_transform_ns_imports --target wasm32-wasip1 && cp ../../target/wasm32-wasip1/release/swc_plugin_transform_ns_imports.wasm .",
+    "build:debug": "cargo build -p swc_plugin_transform_ns_imports --target wasm32-wasip1 && cp ../../target/wasm32-wasip1/debug/swc_plugin_transform_ns_imports.wasm .",
+    "test": "pnpm run build:debug && vitest run --testTimeout=0"
+  },
+  "homepage": "https://swc.rs",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/swc-project/plugins.git",
+    "directory": "packages/transform-ns-imports"
+  },
+  "bugs": {
+    "url": "https://github.com/swc-project/plugins/issues"
+  },
+  "author": "강동윤 <kdy1997.dev@gmail.com>",
+  "keywords": [],
+  "license": "Apache-2.0",
+  "preferUnplugged": true,
+  "dependencies": {
+    "@swc/counter": "^0.1.3"
+  }
+}

--- a/packages/transform-ns-imports/src/lib.rs
+++ b/packages/transform-ns-imports/src/lib.rs
@@ -1,0 +1,19 @@
+#![allow(clippy::not_unsafe_ptr_arg_deref)]
+use swc_core::{
+    ecma::ast::Program,
+    plugin::{plugin_transform, proxies::TransformPluginProgramMetadata},
+};
+
+#[plugin_transform]
+fn transform_ns_imports_plugin(program: Program, data: TransformPluginProgramMetadata) -> Program {
+    let packages = serde_json::from_str(
+        &data
+            .get_transform_plugin_config()
+            .expect("failed to get plugin config for transform-ns-imports"),
+    )
+    .expect("invalid packages");
+
+    program.apply(transform_ns_imports::transform_ns_imports(
+        &transform_ns_imports::Config { packages },
+    ))
+}

--- a/packages/transform-ns-imports/transform/Cargo.toml
+++ b/packages/transform-ns-imports/transform/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+
+description = "AST Transforms for import modularizer"
+
+
+name = "transform_ns_imports"
+
+authors      = { workspace = true }
+edition      = { workspace = true }
+homepage     = { workspace = true }
+license      = { workspace = true }
+repository   = { workspace = true }
+rust-version = { workspace = true }
+version      = "0.89.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+convert_case   = { workspace = true }
+handlebars     = { workspace = true }
+once_cell      = { workspace = true }
+regex          = { workspace = true }
+serde          = { workspace = true, features = ["rc"] }
+swc_atoms      = { workspace = true }
+swc_cached     = { workspace = true }
+swc_common     = { workspace = true }
+swc_ecma_ast   = { workspace = true }
+swc_ecma_visit = { workspace = true }
+
+[dev-dependencies]
+swc_ecma_parser             = { workspace = true }
+swc_ecma_transforms_testing = { workspace = true }
+testing                     = { workspace = true }

--- a/packages/transform-ns-imports/transform/src/lib.rs
+++ b/packages/transform-ns-imports/transform/src/lib.rs
@@ -1,0 +1,239 @@
+use std::{borrow::Cow, collections::HashMap, sync::Arc};
+
+use once_cell::sync::Lazy;
+use regex::{Captures, Regex};
+use serde::Deserialize;
+use swc_atoms::Atom;
+use swc_cached::regex::CachedRegex;
+use swc_common::{util::take::Take, DUMMY_SP};
+use swc_ecma_ast::{ImportDecl, ImportSpecifier, ModuleExportName, *};
+use swc_ecma_visit::{noop_visit_mut_type, visit_mut_pass, VisitMut, VisitMutWith};
+
+static DUP_SLASH_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"//").unwrap());
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(transparent)]
+pub struct Config {
+    pub packages: HashMap<String, Arc<PackageConfig>>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PackageConfig {
+    #[serde(default)]
+    pub rewrite: String,
+}
+
+struct TransformImports<'a> {
+    packages: Vec<(CachedRegex, &'a PackageConfig)>,
+}
+
+struct Rewriter<'a> {
+    key: &'a str,
+    config: &'a PackageConfig,
+    group: Vec<&'a str>,
+}
+
+impl Rewriter<'_> {
+    fn new_path(&self) -> Atom {
+        let new_path = DUP_SLASH_REGEX.replace_all(&self.config.rewrite, |_: &Captures| "/");
+
+        new_path.into()
+    }
+
+    fn rewrite_export(&self, old_decl: &NamedExport) -> Vec<NamedExport> {
+        if old_decl.type_only || old_decl.with.is_some() {
+            return vec![old_decl.clone()];
+        }
+
+        let mut out = Vec::with_capacity(old_decl.specifiers.len());
+
+        for spec in &old_decl.specifiers {
+            match spec {
+                ExportSpecifier::Namespace(ns_spec) => {
+                    let (new_path, specifier) = (
+                        self.new_path(),
+                        ExportSpecifier::Named(ExportNamedSpecifier {
+                            span: DUMMY_SP,
+                            orig: ModuleExportName::Ident(Ident::from("default")),
+                            exported: Some(ns_spec.name.clone()),
+                            is_type_only: false,
+                        }),
+                    );
+
+                    out.push(NamedExport {
+                        specifiers: vec![specifier],
+                        src: Some(Box::new(Str::from(new_path.as_ref()))),
+                        span: old_decl.span,
+                        type_only: false,
+                        with: None,
+                    });
+                }
+                _ => {
+                    return vec![old_decl.clone()];
+                }
+            }
+        }
+        out
+    }
+
+    fn rewrite_import(&self, old_decl: &ImportDecl) -> Vec<ImportDecl> {
+        if old_decl.type_only || old_decl.with.is_some() {
+            return vec![old_decl.clone()];
+        }
+
+        let mut out: Vec<ImportDecl> = Vec::with_capacity(old_decl.specifiers.len());
+
+        for spec in &old_decl.specifiers {
+            match spec {
+                ImportSpecifier::Namespace(ns_spec) => {
+                    let (new_path, specifier) = (
+                        self.new_path(),
+                        ImportSpecifier::Default(ImportDefaultSpecifier {
+                            span: DUMMY_SP,
+                            local: ns_spec.local.clone(),
+                        }),
+                    );
+                    out.push(ImportDecl {
+                        specifiers: vec![specifier],
+                        src: Box::new(Str::from(new_path.as_ref())),
+                        span: old_decl.span,
+                        type_only: false,
+                        with: None,
+                        phase: Default::default(),
+                    });
+                }
+                _ => {
+                    return vec![old_decl.clone()];
+                }
+            }
+        }
+        out
+    }
+}
+
+impl TransformImports<'_> {
+    fn should_rewrite<'a>(&'a self, name: &'a str) -> Option<Rewriter<'a>> {
+        for (regex, config) in &self.packages {
+            let group = regex.captures(name);
+            if let Some(group) = group {
+                let group = group
+                    .iter()
+                    .map(|x| x.map(|x| x.as_str()).unwrap_or_default())
+                    .collect::<Vec<&str>>();
+                return Some(Rewriter {
+                    key: name,
+                    config,
+                    group,
+                });
+            }
+        }
+        None
+    }
+}
+
+impl VisitMut for TransformImports<'_> {
+    noop_visit_mut_type!();
+
+    fn visit_mut_module(&mut self, module: &mut Module) {
+        module.visit_mut_children_with(self);
+
+        let mut new_items: Vec<ModuleItem> = Vec::with_capacity(module.body.len());
+        for item in module.body.take() {
+            match item {
+                ModuleItem::ModuleDecl(ModuleDecl::Import(decl)) => {
+                    if decl.specifiers.is_empty() {
+                        if let Some(rewriter) = self.should_rewrite(&decl.src.value) {
+                            let new_path = rewriter.new_path();
+                            let raw_with_quotes = Atom::from(format!("'{}'", new_path.as_ref()));
+                            let new_src = Box::new(Str {
+                                span: decl.src.span,
+                                value: new_path.clone(),
+                                raw: Some(raw_with_quotes),
+                            });
+                            let new_decl = ImportDecl {
+                                src: new_src,
+                                specifiers: vec![],
+                                ..decl
+                            };
+
+                            new_items.push(ModuleItem::ModuleDecl(ModuleDecl::Import(new_decl)));
+                        } else {
+                            new_items.push(ModuleItem::ModuleDecl(ModuleDecl::Import(decl)));
+                        }
+                        continue;
+                    }
+
+                    match self.should_rewrite(&decl.src.value) {
+                        Some(rewriter) => {
+                            let rewritten = rewriter.rewrite_import(&decl);
+                            new_items.extend(
+                                rewritten
+                                    .into_iter()
+                                    .map(ModuleDecl::Import)
+                                    .map(ModuleItem::ModuleDecl),
+                            );
+                        }
+                        None => new_items.push(ModuleItem::ModuleDecl(ModuleDecl::Import(decl))),
+                    }
+                }
+                ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(
+                    decl @ NamedExport { src: Some(..), .. },
+                )) => match self.should_rewrite(&decl.src.as_deref().unwrap().value) {
+                    Some(rewriter) => {
+                        let rewritten = rewriter.rewrite_export(&decl);
+                        new_items.extend(
+                            rewritten
+                                .into_iter()
+                                .map(ModuleDecl::ExportNamed)
+                                .map(ModuleItem::ModuleDecl),
+                        );
+                    }
+                    None => new_items.push(ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(decl))),
+                },
+
+                ModuleItem::ModuleDecl(ModuleDecl::ExportAll(e @ ExportAll { .. })) => {
+                    match self.should_rewrite(&e.src.value) {
+                        Some(rewriter) => {
+                            let rewritten = rewriter.new_path();
+                            new_items.push(ModuleItem::ModuleDecl(ModuleDecl::ExportAll(
+                                ExportAll {
+                                    src: Box::new(Str {
+                                        span: e.src.span,
+                                        value: rewritten,
+                                        raw: None,
+                                    }),
+                                    ..e
+                                },
+                            )));
+                        }
+                        None => {
+                            new_items.push(ModuleItem::ModuleDecl(ModuleDecl::ExportAll(e)));
+                        }
+                    }
+                }
+                _ => {
+                    new_items.push(item);
+                }
+            }
+        }
+        module.body = new_items;
+    }
+}
+
+pub fn transform_ns_imports(config: &Config) -> impl '_ + Pass {
+    let mut folder = TransformImports { packages: vec![] };
+
+    for (k, v) in &config.packages {
+        let mut k = Cow::Borrowed(k);
+        // XXX: Should we keep this hack?
+        if !k.starts_with('^') && !k.ends_with('$') {
+            k = Cow::Owned(format!("^{k}$"));
+        }
+        folder.packages.push((
+            CachedRegex::new(&k).expect("transform-ns-imports: invalid regex"),
+            v,
+        ));
+    }
+    visit_mut_pass(folder)
+}

--- a/packages/transform-ns-imports/transform/tests/fixture.rs
+++ b/packages/transform-ns-imports/transform/tests/fixture.rs
@@ -1,0 +1,39 @@
+use std::{path::PathBuf, sync::Arc};
+
+use swc_ecma_parser::{EsSyntax, Syntax};
+use swc_ecma_transforms_testing::{test_fixture, FixtureTestConfig};
+use testing::fixture;
+use transform_ns_imports::{transform_ns_imports, PackageConfig};
+
+fn syntax() -> Syntax {
+    Syntax::Es(EsSyntax {
+        jsx: true,
+        ..Default::default()
+    })
+}
+
+#[fixture("tests/fixture/**/input.js")]
+fn transform_ns_imports_fixture(input: PathBuf) {
+    let output = input.parent().unwrap().join("output.js");
+    let config = transform_ns_imports::Config {
+        packages: vec![(
+            "rewrite-module-namespace".to_string(),
+            PackageConfig {
+                rewrite: "rewrite-module-namespace/swc-proxy".into(),
+            },
+        )]
+        .into_iter()
+        .map(|(k, v)| (k, Arc::new(v)))
+        .collect(),
+    };
+
+    test_fixture(
+        syntax(),
+        &|_tr| transform_ns_imports(&config),
+        &input,
+        &output,
+        FixtureTestConfig {
+            ..Default::default()
+        },
+    );
+}

--- a/packages/transform-ns-imports/transform/tests/fixture/rewrite-namespace-export/input.js
+++ b/packages/transform-ns-imports/transform/tests/fixture/rewrite-namespace-export/input.js
@@ -1,0 +1,1 @@
+export * as someModule from "rewrite-module-namespace";

--- a/packages/transform-ns-imports/transform/tests/fixture/rewrite-namespace-export/output.js
+++ b/packages/transform-ns-imports/transform/tests/fixture/rewrite-namespace-export/output.js
@@ -1,0 +1,1 @@
+export { default as someModule } from "rewrite-module-namespace/swc-proxy";

--- a/packages/transform-ns-imports/transform/tests/fixture/rewrite-namespace/input.js
+++ b/packages/transform-ns-imports/transform/tests/fixture/rewrite-namespace/input.js
@@ -1,0 +1,1 @@
+import * as test from 'rewrite-module-namespace'

--- a/packages/transform-ns-imports/transform/tests/fixture/rewrite-namespace/output.js
+++ b/packages/transform-ns-imports/transform/tests/fixture/rewrite-namespace/output.js
@@ -1,0 +1,1 @@
+import test from "rewrite-module-namespace/swc-proxy";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,12 @@ importers:
         specifier: ^0.1.3
         version: 0.1.3
 
+  packages/transform-ns-imports:
+    dependencies:
+      '@swc/counter':
+        specifier: ^0.1.3
+        version: 0.1.3
+
 packages:
 
   '@babel/runtime@7.26.9':
@@ -389,51 +395,61 @@ packages:
     resolution: {integrity: sha512-88I+D3TeKItrw+Y/2ud4Tw0+3CxQ2kLgu3QvrogZ0OfkmX/DEppehus7L3TS2Q4lpB+hYyxhkQiYPJ6Mf5/dPg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.34.9':
     resolution: {integrity: sha512-3qyfWljSFHi9zH0KgtEPG4cBXHDFhwD8kwg6xLfHQ0IWuH9crp005GfoUUh/6w9/FWGBwEHg3lxK1iHRN1MFlA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.34.9':
     resolution: {integrity: sha512-6TZjPHjKZUQKmVKMUowF3ewHxctrRR09eYyvT5eFv8w/fXarEra83A2mHTVJLA5xU91aCNOUnM+DWFMSbQ0Nxw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.34.9':
     resolution: {integrity: sha512-LD2fytxZJZ6xzOKnMbIpgzFOuIKlxVOpiMAXawsAZ2mHBPEYOnLRK5TTEsID6z4eM23DuO88X0Tq1mErHMVq0A==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.34.9':
     resolution: {integrity: sha512-dRAgTfDsn0TE0HI6cmo13hemKpVHOEyeciGtvlBTkpx/F65kTvShtY/EVyZEIfxFkV5JJTuQ9tP5HGBS0hfxIg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.34.9':
     resolution: {integrity: sha512-PHcNOAEhkoMSQtMf+rJofwisZqaU8iQ8EaSps58f5HYll9EAY5BSErCZ8qBDMVbq88h4UxaNPlbrKqfWP8RfJA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.34.9':
     resolution: {integrity: sha512-Z2i0Uy5G96KBYKjeQFKbbsB54xFOL5/y1P5wNBsbXB8yE+At3oh0DVMjQVzCJRJSfReiB2tX8T6HUFZ2k8iaKg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.34.9':
     resolution: {integrity: sha512-U+5SwTMoeYXoDzJX5dhDTxRltSrIax8KWwfaaYcynuJw8mT33W7oOgz0a+AaXtGuvhzTr2tVKh5UO8GVANTxyQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.34.9':
     resolution: {integrity: sha512-FwBHNSOjUTQLP4MG7y6rR6qbGw4MFeQnIBrMe161QGaQoBQLqSUEKlHIiVgF3g/mb3lxlxzJOpIBhaP+C+KP2A==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.34.9':
     resolution: {integrity: sha512-cYRpV4650z2I3/s6+5/LONkjIz8MBeqrk+vPXV10ORBnshpn8S32bPqQ2Utv39jCiDcO2eJTuSlPXpnvmaIgRA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.34.9':
     resolution: {integrity: sha512-z4mQK9dAN6byRA/vsSgQiPeuO63wdiDxZ9yg9iyX2QTzKuQM7T4xlBoeUP/J8uiFkqxkcWndWi+W7bXdPbt27Q==}
@@ -473,24 +489,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.12.0':
     resolution: {integrity: sha512-OeFHz/5Hl9v75J9TYA5jQxNIYAZMqaiPpd9dYSTK2Xyqa/ZGgTtNyPhIwVfxx+9mHBf6+9c1mTlXUtACMtHmaQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.12.0':
     resolution: {integrity: sha512-ltIvqNi7H0c5pRawyqjeYSKEIfZP4vv/datT3mwT6BW7muJtd1+KIDCPFLMIQ4wm/h76YQwPocsin3fzmnFdNA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.12.0':
     resolution: {integrity: sha512-Z/DhpjehaTK0uf+MhNB7mV9SuewpGs3P/q9/8+UsJeYoFr7yuOoPbAvrD6AqZkf6Bh7MRZ5OtG+KQgG5L+goiA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.12.0':
     resolution: {integrity: sha512-wHnvbfHIh2gfSbvuFT7qP97YCMUDh+fuiso+pcC6ug8IsMxuViNapHET4o0ZdFNWHhXJ7/s0e6w7mkOalsqQiQ==}


### PR DESCRIPTION
Add `@swc/plugin-transform-ns-imports` to support namespace rewrite due to import syntax are language level feature, and cannot set a proxy object for the exports module.

Add it transform reexport from:
```ts
export * as someModule from "rewrite-module-namespace";
```

to: 
```ts
export { default as someModule } from "rewrite-module-namespace/swc-proxy";
```


and transform import from:
```ts
import * as test from 'rewrite-module-namespace'
```

to: 
```ts
import test from "rewrite-module-namespace/swc-proxy";
```

So we can make the `swc-proxy` file content see like: 

```ts
import { lazy } from 'react' 

const modules = {};
export default new Proxy(modules, {
   get(name) {
      return lazy(() => import(`module/${name}`);
   }
})
```

