### PR TITLE
fix(formatjs): Fix ast tansform in jsx

### DIFF
--- a/.changeset/honest-walls-smile.md
+++ b/.changeset/honest-walls-smile.md
@@ -1,0 +1,5 @@
+---
+"@swc/plugin-formatjs": patch
+---
+
+fix(formatjs): Fix ast transform in jsx

--- a/packages/formatjs/__tests__/__snapshots__/wasm.test.ts.snap
+++ b/packages/formatjs/__tests__/__snapshots__/wasm.test.ts.snap
@@ -50,3 +50,37 @@ formatMessage({
 });
 "
 `;
+
+exports[`formatjs swc plugin > should transform to ast when enabled 1`] = `
+"import { defineMessage, formatMessage, FormattedMessage } from 'react-intl';
+var helloWorldMessage = formatMessage({
+    id: "wVJ82J",
+    defaultMessage: [
+        {
+            "type": 0,
+            "value": "Hello, world!"
+        }
+    ]
+});
+var helloWorld = defineMessage({
+    id: "AlnfGI",
+    defaultMessage: [
+        {
+            "type": 0,
+            "value": "Hello, world!"
+        }
+    ]
+});
+export function Greeting() {
+    return /*#__PURE__*/ React.createElement(FormattedMessage, {
+        id: "wVJ82J",
+        defaultMessage: [
+            {
+                "type": 0,
+                "value": "Hello, world!"
+            }
+        ]
+    });
+}
+"
+`;

--- a/packages/formatjs/__tests__/wasm.test.ts
+++ b/packages/formatjs/__tests__/wasm.test.ts
@@ -94,6 +94,31 @@ describe("formatjs swc plugin", () => {
     expect(output).not.toMatch(/description/);
   });
 
+  it("should transform to ast when enabled", async () => {
+    const input = `
+      import { defineMessage, formatMessage, FormattedMessage } from 'react-intl';
+
+      const helloWorldMessage = formatMessage({
+        defaultMessage: "Hello, world!",
+      });
+
+      const helloWorld = defineMessage({
+        defaultMessage: "Hello, world!",
+        description: "A simple greeting",
+      });
+
+      export function Greeting() {
+        return (
+          <FormattedMessage defaultMessage="Hello, world!" />
+        );
+      }
+    `;
+
+    const code = await transformCode(input, { ast: true });
+
+    expect(code).toMatchSnapshot();
+  });
+
   it("should handle formatMessage calls", async () => {
     const input = `
       import { useIntl } from 'react-intl';


### PR DESCRIPTION
- Ensure messages in function calls and JSX are transformed to AST format when the ast option is set.
- Update tests and snapshots to reflect the correct AST output.

Fixes #497

Fixes an issue where messages were not being transformed to AST format when the ast option was enabled.
Now, both function calls and JSX components correctly output the defaultMessage as an AST when requested.

Also added a snapshot test for both `defineMessage`, `formatMessage` and `FormattedMessage`.