### PR TITLE
fix(formatjs): Fix description extract for the template literal string

### DIFF
--- a/.changeset/rotten-lions-smell.md
+++ b/.changeset/rotten-lions-smell.md
@@ -1,0 +1,5 @@
+---
+"@swc/plugin-formatjs": patch
+---
+
+fix(formatjs): Fix description extract for the template literal string

--- a/packages/formatjs/__tests__/wasm.test.ts
+++ b/packages/formatjs/__tests__/wasm.test.ts
@@ -451,4 +451,61 @@ describe("formatjs swc plugin", () => {
 
     expect(code).toMatchSnapshot();
   });
+
+  it("should generate same id even if description is an template literal string", async () => {
+    const input1 = `
+      import { FormattedMessage } from 'react-intl';
+
+      export function Greeting() {
+        return (
+          <FormattedMessage
+            defaultMessage="Hello, World!"
+            description="Greeting message"
+          />
+        );
+      }
+    `;
+
+    const input2 = `
+      import { FormattedMessage } from 'react-intl';
+
+      export function Greeting() {
+        return (
+          <FormattedMessage
+            defaultMessage="Hello, World!"
+            description={\`Greeting message\`}
+          />
+        );
+      }
+    `;
+
+    const input3 = `
+      import { FormattedMessage } from 'react-intl';
+
+      const description = \`Greeting message\`;
+
+      export function Greeting() {
+        return (
+          <FormattedMessage
+            defaultMessage="Hello, World!"
+            description={description}
+          />
+        );
+      }
+    `;
+
+    const code1 = await transformCode(input1, {
+      idInterpolationPattern: "[sha512:contenthash:base64:6]",
+    });
+    const code2 = await transformCode(input2, {
+      idInterpolationPattern: "[sha512:contenthash:base64:6]",
+    });
+    const code3 = await transformCode(input3, {
+      idInterpolationPattern: "[sha512:contenthash:base64:6]",
+    });
+
+    expect(code1).toMatch(/id: "Ae\/S0P"/);
+    expect(code2).toMatch(/id: "Ae\/S0P"/);
+    expect(code3).toMatch(/id: "Ae\/S0P"/);
+  });
 });

--- a/packages/formatjs/transform/src/lib.rs
+++ b/packages/formatjs/transform/src/lib.rs
@@ -744,13 +744,8 @@ fn evaluate_template_literal_string(tpl: &Tpl) -> String {
     //NOTE: This doesn't fully evaluate templates
     tpl.quasis
         .iter()
-        .map(|q| {
-            q.cooked
-                .as_ref()
-                .map(|v| v.to_string())
-                .unwrap_or("".to_string())
-        })
-        .collect::<Vec<String>>()
+        .map(|q| q.cooked.as_deref().unwrap_or_default())
+        .collect::<Vec<&str>>()
         .join("")
 }
 


### PR DESCRIPTION
I made a fix that correctly handles the extraction of descriptions wrapped in template string literals. The current behavior was resulting in the generation of an incorrect identifier. This pull request fixes this issue.

```jsx
// source
<FormattedMessage
  defaultMessage="Hello, World!"
  description="Greeting message"
/>
<FormattedMessage
  defaultMessage="Hello, World!"
  description={`Greeting message`}
/>

// transformed
_jsx(FormattedMessage, {
    id: "Ae/S0P"
});
_jsx(FormattedMessage, {
    id: "N015Sp",
    description: "Greeting message"
});
```
