### PR TITLE
feat(transform-import): Add style option to fully replace babel-plugin-import

### DIFF
--- a/packages/transform-imports/__tests__/__snapshots__/wasm.test.ts.snap
+++ b/packages/transform-imports/__tests__/__snapshots__/wasm.test.ts.snap
@@ -1,5 +1,15 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Should load transform-imports wasm plugin correctly > Should transform antd correctly 1`] = `
+"import Button from "antd/lib/button";
+import "antd/lib/button/style";
+import Card from "antd/lib/card";
+import "antd/lib/card/style";
+import InputNumber from "antd/lib/input-number";
+import "antd/lib/input-number/style";
+"
+`;
+
 exports[`Should load transform-imports wasm plugin correctly > Should transform default correctly 1`] = `
 "import defaultExport from "my-default";
 "

--- a/packages/transform-imports/__tests__/wasm.test.ts
+++ b/packages/transform-imports/__tests__/wasm.test.ts
@@ -61,6 +61,14 @@ const transformCode = async (
       handleDefaultImport: false,
       handleNamespaceImport: false,
     },
+    antd: {
+      transform: "antd/lib/{{ kebabCase member }}",
+      prevent_full_import: false,
+      skip_default_conversion: false,
+      handle_default_import: true,
+      handle_namespace_import: true,
+      style: "style",
+    },
   },
 ) => {
   return transform(code, {

--- a/packages/transform-imports/transform/tests/fixture.rs
+++ b/packages/transform-imports/transform/tests/fixture.rs
@@ -25,6 +25,7 @@ fn modularize_imports_fixture(input: PathBuf) {
                     skip_default_conversion: false,
                     handle_default_import: true,
                     handle_namespace_import: true,
+                    style: None,
                 },
             ),
             (
@@ -35,6 +36,7 @@ fn modularize_imports_fixture(input: PathBuf) {
                     skip_default_conversion: false,
                     handle_default_import: true,
                     handle_namespace_import: true,
+                    style: None,
                 },
             ),
             (
@@ -45,6 +47,7 @@ fn modularize_imports_fixture(input: PathBuf) {
                     skip_default_conversion: true,
                     handle_default_import: true,
                     handle_namespace_import: true,
+                    style: None,
                 },
             ),
             (
@@ -55,6 +58,7 @@ fn modularize_imports_fixture(input: PathBuf) {
                     skip_default_conversion: true,
                     handle_default_import: true,
                     handle_namespace_import: true,
+                    style: None,
                 },
             ),
             (
@@ -82,6 +86,7 @@ fn modularize_imports_fixture(input: PathBuf) {
                     skip_default_conversion: true,
                     handle_default_import: true,
                     handle_namespace_import: true,
+                    style: None,
                 },
             ),
             (
@@ -92,6 +97,7 @@ fn modularize_imports_fixture(input: PathBuf) {
                     skip_default_conversion: true,
                     handle_default_import: true,
                     handle_namespace_import: true,
+                    style: None,
                 },
             ),
             (
@@ -102,6 +108,18 @@ fn modularize_imports_fixture(input: PathBuf) {
                     skip_default_conversion: false,
                     handle_default_import: false,
                     handle_namespace_import: false,
+                    style: None,
+                },
+            ),
+            (
+                "antd".to_string(),
+                PackageConfig {
+                    transform: "antd/lib/{{ kebabCase member }}".into(),
+                    prevent_full_import: false,
+                    skip_default_conversion: false,
+                    handle_default_import: true,
+                    handle_namespace_import: true,
+                    style: Some("style".to_string()),
                 },
             ),
         ]

--- a/packages/transform-imports/transform/tests/fixture/antd/input.js
+++ b/packages/transform-imports/transform/tests/fixture/antd/input.js
@@ -1,0 +1,1 @@
+import { Button, Card, InputNumber } from 'antd';

--- a/packages/transform-imports/transform/tests/fixture/antd/output.js
+++ b/packages/transform-imports/transform/tests/fixture/antd/output.js
@@ -1,0 +1,6 @@
+import Button from "antd/lib/button";
+import "antd/lib/button/style";
+import Card from "antd/lib/card";
+import "antd/lib/card/style";
+import InputNumber from "antd/lib/input-number";
+import "antd/lib/input-number/style";


### PR DESCRIPTION
It looks like the transform-import plugin is just one option away from fully replace babel-plugin-import. When compiling imports of web component libraries like ant-design, babel-plugin-import will transform following import:

```typescript
import { Button, InputNumber } from 'antd';
```

into 

```typescript
import Button from 'antd/lib/button';
import 'antd/lib/button/style';
import InputNumber from 'antd/lib/input-number';
import 'antd/lib/input-number/style';
```

Hence a corresponding `config.style` option is added to make transform-import plugin able to perform similar action.  Should be able to close https://github.com/swc-project/swc/discussions/3042 for good.