### PR TITLE
fix(contrib/graphql): Add import below directives

### DIFF
--- a/.changeset/puny-crabs-hang.md
+++ b/.changeset/puny-crabs-hang.md
@@ -1,0 +1,5 @@
+---
+"@swc-contrib/plugin-graphql-codegen-client-preset": patch
+---
+
+Add import below directives

--- a/contrib/graphql-codegen-client-preset/src/tests.rs
+++ b/contrib/graphql-codegen-client-preset/src/tests.rs
@@ -88,3 +88,59 @@ test!(
     const looseToArray = (input)=>[].slice.call(input);
     const targetTag = document.querySelector(`style[data-n-href="${href}"]`);"#
 );
+
+test!(
+    Default::default(),
+    |_| visit_mut_pass(get_test_code_visitor()),
+    preserves_use_cache_directive,
+    r#""use cache";
+
+import gql from "gql-tag";
+
+const GetUser = gql(`
+  query GetUser {
+    user {
+      id
+      name
+    }
+  }
+`);
+
+const CreatePost = gql(`
+  mutation CreatePost($input: PostInput!) {
+    createPost(input: $input) {
+      id
+      title
+    }
+  }
+`);"#
+);
+
+test!(
+    Default::default(),
+    |_| visit_mut_pass(get_test_code_visitor()),
+    preserves_multiple_directives,
+    r#""use strict";
+"use cache";
+
+import gql from "gql-tag";
+
+const GetData = gql(`
+  query GetData {
+    data
+  }
+`);"#
+);
+
+test!(
+    Default::default(),
+    |_| visit_mut_pass(get_test_code_visitor()),
+    works_without_directives,
+    r#"import gql from "gql-tag";
+
+const GetData = gql(`
+  query GetData {
+    data
+  }
+`);"#
+);

--- a/contrib/graphql-codegen-client-preset/tests/__swc_snapshots__/src/tests.rs/preserves_multiple_directives.js
+++ b/contrib/graphql-codegen-client-preset/tests/__swc_snapshots__/src/tests.rs/preserves_multiple_directives.js
@@ -1,0 +1,5 @@
+"use strict";
+"use cache";
+import { GetDataDocument } from "./src/gql/graphql";
+import gql from "gql-tag";
+const GetData = GetDataDocument;

--- a/contrib/graphql-codegen-client-preset/tests/__swc_snapshots__/src/tests.rs/preserves_use_cache_directive.js
+++ b/contrib/graphql-codegen-client-preset/tests/__swc_snapshots__/src/tests.rs/preserves_use_cache_directive.js
@@ -1,0 +1,6 @@
+"use cache";
+import { GetUserDocument } from "./src/gql/graphql";
+import { CreatePostDocument } from "./src/gql/graphql";
+import gql from "gql-tag";
+const GetUser = GetUserDocument;
+const CreatePost = CreatePostDocument;

--- a/contrib/graphql-codegen-client-preset/tests/__swc_snapshots__/src/tests.rs/works_without_directives.js
+++ b/contrib/graphql-codegen-client-preset/tests/__swc_snapshots__/src/tests.rs/works_without_directives.js
@@ -1,0 +1,3 @@
+import { GetDataDocument } from "./src/gql/graphql";
+import gql from "gql-tag";
+const GetData = GetDataDocument;

--- a/contrib/graphql-codegen-client-preset/tests/fixtures/multiple-directives.ts
+++ b/contrib/graphql-codegen-client-preset/tests/fixtures/multiple-directives.ts
@@ -1,0 +1,10 @@
+"use strict";
+"use cache";
+
+import gql from "gql-tag";
+
+const GetData = gql(/* GraphQL */ `
+  query GetData {
+    data
+  }
+`);

--- a/contrib/graphql-codegen-client-preset/tests/fixtures/simple-uppercase-operation-name.js
+++ b/contrib/graphql-codegen-client-preset/tests/fixtures/simple-uppercase-operation-name.js
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */ //@ts-ignore
-import { CFragmentDoc } from "./graphql";
-import { BDocument } from "./graphql";
 import { ADocument } from "./graphql";
+import { BDocument } from "./graphql";
+import { CFragmentDoc } from "./graphql";
 import gql from "gql-tag";
 //@ts-ignore
 const A = ADocument;

--- a/contrib/graphql-codegen-client-preset/tests/fixtures/simple-uppercase-operation-name.other-dir.js
+++ b/contrib/graphql-codegen-client-preset/tests/fixtures/simple-uppercase-operation-name.other-dir.js
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */ //@ts-ignore
-import { CFragmentDoc } from "./../graphql";
-import { BDocument } from "./../graphql";
 import { ADocument } from "./../graphql";
+import { BDocument } from "./../graphql";
+import { CFragmentDoc } from "./../graphql";
 import gql from "gql-tag";
 //@ts-ignore
 const A = ADocument;

--- a/contrib/graphql-codegen-client-preset/tests/fixtures/use-cache-directive.ts
+++ b/contrib/graphql-codegen-client-preset/tests/fixtures/use-cache-directive.ts
@@ -1,0 +1,21 @@
+"use cache";
+
+import gql from "gql-tag";
+
+const GetUser = gql(/* GraphQL */ `
+  query GetUser {
+    user {
+      id
+      name
+    }
+  }
+`);
+
+const CreatePost = gql(/* GraphQL */ `
+  mutation CreatePost($input: PostInput!) {
+    createPost(input: $input) {
+      id
+      title
+    }
+  }
+`);


### PR DESCRIPTION
Directives like "use strict", "use client" or "use cache" should always be on top. Inserting an import statement on the first line breaks this.

For example with nextjs:
```
Ecmascript file had an error
> 1 | "use cache";
    | ^^^^^^^^^^^
  2 | import { cacheLife } from "next/dist/server/use-cache/cache-life";
  3 | import { cacheTag } from "next/dist/server/use-cache/cache-tag";
  4 | import { notFound } from "next/navigation";

The "use cache" directive must be at the top of the file.
```

This change will first scan if there is a line with "use ", and insert the import below it.