### PR TITLE
feat(formatjs): Add support for string concatenation in message definitions

### DIFF
--- a/packages/formatjs/__tests__/wasm.test.ts
+++ b/packages/formatjs/__tests__/wasm.test.ts
@@ -94,6 +94,62 @@ describe("formatjs swc plugin", () => {
     expect(output).not.toMatch(/description/);
   });
 
+  it("should handle string concatenation in defaultMessage", async () => {
+    const input = `
+      import { defineMessage } from 'react-intl';
+
+      const message = defineMessage({
+        defaultMessage: "Foo " + "Bar",
+        description: "foobar"
+      });
+    `;
+
+    const output = await transformCode(input);
+
+    expect(output).toMatch(/id: "[^"]+"/);
+    expect(output).toMatch(/defaultMessage: "Foo Bar"/);
+    expect(output).not.toMatch(/description/);
+  });
+
+  it("should handle multiple string concatenations", async () => {
+    const input = `
+      import { defineMessage } from 'react-intl';
+
+      const message = defineMessage({
+        defaultMessage: "This is " + "a very " + "long message",
+        description: "multi concat"
+      });
+    `;
+
+    const output = await transformCode(input);
+
+    expect(output).toMatch(/id: "[^"]+"/);
+    expect(output).toMatch(/defaultMessage: "This is a very long message"/);
+    expect(output).not.toMatch(/description/);
+  });
+
+  it("should handle string concatenation in FormattedMessage JSX", async () => {
+    const input = `
+      import React from 'react';
+      import { FormattedMessage } from 'react-intl';
+
+      export function Greeting() {
+        return (
+          <FormattedMessage
+            defaultMessage={"Hello " + "World"}
+            description="jsx concat"
+          />
+        );
+      }
+    `;
+
+    const output = await transformCode(input);
+
+    expect(output).toMatch(/id: "[^"]+"/);
+    expect(output).toMatch(/defaultMessage: "Hello World"/);
+    expect(output).not.toMatch(/description/);
+  });
+
   it("should transform to ast when enabled", async () => {
     const input = `
       import { defineMessage, formatMessage, FormattedMessage } from 'react-intl';


### PR DESCRIPTION
Fixes https://github.com/swc-project/plugins/issues/446

[warning: AI driven solution using Opus 4.1]

This update introduces the ability to handle string concatenation in both `defaultMessage` and `FormattedMessage` JSX components. New tests have been added to ensure correct transformation of concatenated strings into a single message. Additionally, helper functions for evaluating binary expressions have been implemented in the Rust codebase to support this feature.