### PR TITLE
fix(relay): Fix typo in types

### DIFF
--- a/.changeset/blue-rivers-leave.md
+++ b/.changeset/blue-rivers-leave.md
@@ -1,0 +1,5 @@
+---
+"@swc/plugin-relay": patch
+---
+
+Fix typo in config types

--- a/packages/relay/types.d.ts
+++ b/packages/relay/types.d.ts
@@ -2,7 +2,7 @@ declare module "@swc/plugin-relay" {
   export interface Config {
     rootDir: string;
     artifactDirectory?: string;
-    language: "typescript" | "javascrip" | "flow";
+    language: "typescript" | "javascript" | "flow";
     eagerEsModules?: boolean;
   }
 }


### PR DESCRIPTION
The config types for `@swc/plugin-relay` incorrectly listed `"javascrip"` instead of `"javascript"` in the `language` options.