### PR TITLE
feat(graphql-codegen): configurable document/fragment variable naming

### DIFF
--- a/.changeset/configurable-variable-naming.md
+++ b/.changeset/configurable-variable-naming.md
@@ -1,0 +1,5 @@
+---
+"@swc-contrib/plugin-graphql-codegen-client-preset": minor
+---
+
+Add configurable document/fragment variable prefix, suffix, dedupeOperationSuffix, and omitOperationSuffix options matching @graphql-codegen/client-preset

--- a/contrib/graphql-codegen-client-preset/README.md
+++ b/contrib/graphql-codegen-client-preset/README.md
@@ -16,6 +16,19 @@ You will need to provide the `artifactDirectory` path that should be the same as
 
 The plugin also supports a `namingConvention` option to match the naming convention configured in your `codegen.ts`. The default is `"change-case-all#pascalCase"` which matches the default for `@graphql-codegen/client-preset`. If you have set `namingConvention: "change-case-all#upperCaseFirst"` in your `codegen.ts`, you must also set it in the plugin options.
 
+#### Variable prefix/suffix options
+
+By default the plugin appends `"Document"` to operation names and `"FragmentDoc"` to fragment names when generating import identifiers — matching the `@graphql-codegen/client-preset` defaults. If you've changed these in your codegen config, set the same values here so the plugin generates matching imports.
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `documentVariablePrefix` | `""` | Prefix for operation variable names |
+| `documentVariableSuffix` | `"Document"` | Suffix for operation variable names |
+| `fragmentVariablePrefix` | `""` | Prefix for fragment variable names |
+| `fragmentVariableSuffix` | `"FragmentDoc"` | Suffix for fragment variable names |
+| `dedupeOperationSuffix` | `false` | When `true`, deduplicates overlapping suffix on fragments (e.g. `MyFragment` + `FragmentDoc` → `MyFragmentDoc` instead of `MyFragmentFragmentDoc`) |
+| `omitOperationSuffix` | `false` | When `true`, omits the fragment variable suffix entirely |
+
 #### Vite
 
 ```ts

--- a/contrib/graphql-codegen-client-preset/src/lib.rs
+++ b/contrib/graphql-codegen-client-preset/src/lib.rs
@@ -122,6 +122,12 @@ pub struct GraphQLCodegenOptions {
     pub artifact_directory: String,
     pub gql_tag_name: String,
     pub naming_convention: String,
+    pub document_variable_prefix: String,
+    pub document_variable_suffix: String,
+    pub fragment_variable_prefix: String,
+    pub fragment_variable_suffix: String,
+    pub dedupe_operation_suffix: bool,
+    pub omit_operation_suffix: bool,
 }
 
 pub struct GraphQLVisitor {
@@ -134,6 +140,23 @@ impl GraphQLVisitor {
         GraphQLVisitor {
             options,
             graphql_operations_or_fragments_to_import: Vec::new(),
+        }
+    }
+
+    fn resolve_fragment_suffix(&self, fragment_name: &str) -> &str {
+        if self.options.omit_operation_suffix {
+            ""
+        } else if self.options.dedupe_operation_suffix
+            && fragment_name.to_lowercase().ends_with("fragment")
+            && self
+                .options
+                .fragment_variable_suffix
+                .to_lowercase()
+                .starts_with("fragment")
+        {
+            &self.options.fragment_variable_suffix["fragment".len()..]
+        } else {
+            &self.options.fragment_variable_suffix
         }
     }
 
@@ -246,29 +269,31 @@ impl VisitMut for GraphQLVisitor {
 
                     let operation_name = match first_definition {
                         graphql_parser::query::Definition::Fragment(fragment) => {
-                            fragment.name.to_string() + "FragmentDoc"
+                            let suffix = self.resolve_fragment_suffix(fragment.name);
+                            format!(
+                                "{}{}{}",
+                                self.options.fragment_variable_prefix, fragment.name, suffix
+                            )
                         }
-                        graphql_parser::query::Definition::Operation(op) => match op {
-                            graphql_parser::query::OperationDefinition::Query(query) => {
-                                match query.name {
-                                    Some(name) => name.to_string() + "Document",
-                                    None => return,
+                        graphql_parser::query::Definition::Operation(op) => {
+                            let name = match op {
+                                graphql_parser::query::OperationDefinition::Query(q) => q.name,
+                                graphql_parser::query::OperationDefinition::Mutation(m) => m.name,
+                                graphql_parser::query::OperationDefinition::Subscription(s) => {
+                                    s.name
                                 }
-                            }
-                            graphql_parser::query::OperationDefinition::Mutation(mutation) => {
-                                match mutation.name {
-                                    Some(name) => name.to_string() + "Document",
-                                    None => return,
-                                }
-                            }
-                            graphql_parser::query::OperationDefinition::Subscription(
-                                subscription,
-                            ) => match subscription.name {
-                                Some(name) => name.to_string() + "Document",
+                                _ => return,
+                            };
+                            match name {
+                                Some(name) => format!(
+                                    "{}{}{}",
+                                    self.options.document_variable_prefix,
+                                    name,
+                                    self.options.document_variable_suffix
+                                ),
                                 None => return,
-                            },
-                            _ => return,
-                        },
+                            }
+                        }
                     };
 
                     let import_name =
@@ -349,6 +374,14 @@ fn naming_convention_default() -> String {
     "change-case-all#pascalCase".to_string()
 }
 
+fn document_variable_suffix_default() -> String {
+    "Document".to_string()
+}
+
+fn fragment_variable_suffix_default() -> String {
+    "FragmentDoc".to_string()
+}
+
 #[derive(Deserialize)]
 #[serde(untagged)]
 enum NamingConventionOption {
@@ -383,6 +416,24 @@ struct PluginOptions {
 
     #[serde(default = "naming_convention_option_default")]
     namingConvention: NamingConventionOption,
+
+    #[serde(default)]
+    documentVariablePrefix: String,
+
+    #[serde(default = "document_variable_suffix_default")]
+    documentVariableSuffix: String,
+
+    #[serde(default)]
+    fragmentVariablePrefix: String,
+
+    #[serde(default = "fragment_variable_suffix_default")]
+    fragmentVariableSuffix: String,
+
+    #[serde(default)]
+    dedupeOperationSuffix: bool,
+
+    #[serde(default)]
+    omitOperationSuffix: bool,
 }
 
 #[plugin_transform]
@@ -414,6 +465,12 @@ pub fn process_transform(program: Program, metadata: TransformPluginProgramMetad
         artifact_directory,
         gql_tag_name: plugin_config.gqlTagName,
         naming_convention: plugin_config.namingConvention.as_type_name_convention(),
+        document_variable_prefix: plugin_config.documentVariablePrefix,
+        document_variable_suffix: plugin_config.documentVariableSuffix,
+        fragment_variable_prefix: plugin_config.fragmentVariablePrefix,
+        fragment_variable_suffix: plugin_config.fragmentVariableSuffix,
+        dedupe_operation_suffix: plugin_config.dedupeOperationSuffix,
+        omit_operation_suffix: plugin_config.omitOperationSuffix,
     });
 
     program.apply(&mut visit_mut_pass(visitor))

--- a/contrib/graphql-codegen-client-preset/src/tests.rs
+++ b/contrib/graphql-codegen-client-preset/src/tests.rs
@@ -18,6 +18,12 @@ fn get_test_code_visitor() -> GraphQLVisitor {
         artifact_directory: "./src/gql".to_string(),
         gql_tag_name: "gql".to_string(),
         naming_convention: "change-case-all#pascalCase".to_string(),
+        document_variable_prefix: "".to_string(),
+        document_variable_suffix: "Document".to_string(),
+        fragment_variable_prefix: "".to_string(),
+        fragment_variable_suffix: "FragmentDoc".to_string(),
+        dedupe_operation_suffix: false,
+        omit_operation_suffix: false,
     })
 }
 
@@ -28,6 +34,12 @@ fn get_test_code_visitor_upper_case_first() -> GraphQLVisitor {
         artifact_directory: "./src/gql".to_string(),
         gql_tag_name: "gql".to_string(),
         naming_convention: "change-case-all#upperCaseFirst".to_string(),
+        document_variable_prefix: "".to_string(),
+        document_variable_suffix: "Document".to_string(),
+        fragment_variable_prefix: "".to_string(),
+        fragment_variable_suffix: "FragmentDoc".to_string(),
+        dedupe_operation_suffix: false,
+        omit_operation_suffix: false,
     })
 }
 
@@ -52,6 +64,12 @@ fn import_files_from_same_directory(input_path: PathBuf) {
                 artifact_directory: "./tests/fixtures".to_string(),
                 gql_tag_name: "gql".to_string(),
                 naming_convention: "change-case-all#pascalCase".to_string(),
+                document_variable_prefix: "".to_string(),
+                document_variable_suffix: "Document".to_string(),
+                fragment_variable_prefix: "".to_string(),
+                fragment_variable_suffix: "FragmentDoc".to_string(),
+                dedupe_operation_suffix: false,
+                omit_operation_suffix: false,
             }))
         },
         &input_path,
@@ -84,6 +102,12 @@ fn import_files_from_other_directory(input_path: PathBuf) {
                 artifact_directory: cwd.to_string_lossy().to_string(),
                 gql_tag_name: "gql".to_string(),
                 naming_convention: "change-case-all#pascalCase".to_string(),
+                document_variable_prefix: "".to_string(),
+                document_variable_suffix: "Document".to_string(),
+                fragment_variable_prefix: "".to_string(),
+                fragment_variable_suffix: "FragmentDoc".to_string(),
+                dedupe_operation_suffix: false,
+                omit_operation_suffix: false,
             }))
         },
         &input_path,
@@ -102,6 +126,12 @@ fn get_windows_path_visitor() -> GraphQLVisitor {
         artifact_directory: "C:\\Users\\user\\project\\src\\gql".to_string(),
         gql_tag_name: "gql".to_string(),
         naming_convention: "change-case-all#pascalCase".to_string(),
+        document_variable_prefix: "".to_string(),
+        document_variable_suffix: "Document".to_string(),
+        fragment_variable_prefix: "".to_string(),
+        fragment_variable_suffix: "FragmentDoc".to_string(),
+        dedupe_operation_suffix: false,
+        omit_operation_suffix: false,
     })
 }
 
@@ -219,6 +249,318 @@ const SomeEGRockets = gql(`
   }
 `);"#
 );
+
+fn get_test_code_visitor_empty_document_suffix() -> GraphQLVisitor {
+    GraphQLVisitor::new(GraphQLCodegenOptions {
+        filename: "test.ts".to_string(),
+        cwd: "/home/faketestproject".to_string(),
+        artifact_directory: "./src/gql".to_string(),
+        gql_tag_name: "gql".to_string(),
+        naming_convention: "change-case-all#pascalCase".to_string(),
+        document_variable_prefix: "".to_string(),
+        document_variable_suffix: "".to_string(),
+        fragment_variable_prefix: "".to_string(),
+        fragment_variable_suffix: "FragmentDoc".to_string(),
+        dedupe_operation_suffix: false,
+        omit_operation_suffix: false,
+    })
+}
+
+fn get_test_code_visitor_custom_suffixes() -> GraphQLVisitor {
+    GraphQLVisitor::new(GraphQLCodegenOptions {
+        filename: "test.ts".to_string(),
+        cwd: "/home/faketestproject".to_string(),
+        artifact_directory: "./src/gql".to_string(),
+        gql_tag_name: "gql".to_string(),
+        naming_convention: "change-case-all#pascalCase".to_string(),
+        document_variable_prefix: "".to_string(),
+        document_variable_suffix: "Doc".to_string(),
+        fragment_variable_prefix: "".to_string(),
+        fragment_variable_suffix: "Frag".to_string(),
+        dedupe_operation_suffix: false,
+        omit_operation_suffix: false,
+    })
+}
+
+test!(
+    Default::default(),
+    |_| visit_mut_pass(get_test_code_visitor_empty_document_suffix()),
+    empty_document_suffix_uses_operation_name_directly,
+    r#"import gql from "gql-tag";
+
+const GetUser = gql(`
+  query GetUser {
+    user {
+      id
+    }
+  }
+`);"#
+);
+
+test!(
+    Default::default(),
+    |_| visit_mut_pass(get_test_code_visitor_custom_suffixes()),
+    custom_document_suffix,
+    r#"import gql from "gql-tag";
+
+const GetUser = gql(`
+  query GetUser {
+    user {
+      id
+    }
+  }
+`);"#
+);
+
+test!(
+    Default::default(),
+    |_| visit_mut_pass(get_test_code_visitor_custom_suffixes()),
+    custom_fragment_suffix,
+    r#"import gql from "gql-tag";
+
+const UserFields = gql(`
+  fragment UserFields on User {
+    id
+    name
+  }
+`);"#
+);
+
+fn get_test_code_visitor_with_prefix() -> GraphQLVisitor {
+    GraphQLVisitor::new(GraphQLCodegenOptions {
+        filename: "test.ts".to_string(),
+        cwd: "/home/faketestproject".to_string(),
+        artifact_directory: "./src/gql".to_string(),
+        gql_tag_name: "gql".to_string(),
+        naming_convention: "change-case-all#pascalCase".to_string(),
+        document_variable_prefix: "Gql_".to_string(),
+        document_variable_suffix: "".to_string(),
+        fragment_variable_prefix: "Gql_".to_string(),
+        fragment_variable_suffix: "".to_string(),
+        dedupe_operation_suffix: false,
+        omit_operation_suffix: false,
+    })
+}
+
+test!(
+    Default::default(),
+    |_| visit_mut_pass(get_test_code_visitor_with_prefix()),
+    document_variable_prefix_applied,
+    r#"import gql from "gql-tag";
+
+const GetUser = gql(`
+  query GetUser {
+    user {
+      id
+    }
+  }
+`);"#
+);
+
+#[test]
+fn plugin_options_default_prefix_and_suffix_values() {
+    let options: PluginOptions = serde_json::from_str(
+        r#"{"artifactDirectory":"./src/gql"}"#,
+    )
+    .unwrap();
+
+    assert_eq!(options.documentVariablePrefix, "");
+    assert_eq!(options.documentVariableSuffix, "Document");
+    assert_eq!(options.fragmentVariablePrefix, "");
+    assert_eq!(options.fragmentVariableSuffix, "FragmentDoc");
+}
+
+#[test]
+fn plugin_options_accept_custom_prefix_and_suffix_values() {
+    let options: PluginOptions = serde_json::from_str(
+        r#"{
+            "artifactDirectory":"./src/gql",
+            "documentVariablePrefix":"Gql_",
+            "documentVariableSuffix":"",
+            "fragmentVariablePrefix":"Gql_",
+            "fragmentVariableSuffix":"Frag"
+        }"#,
+    )
+    .unwrap();
+
+    assert_eq!(options.documentVariablePrefix, "Gql_");
+    assert_eq!(options.documentVariableSuffix, "");
+    assert_eq!(options.fragmentVariablePrefix, "Gql_");
+    assert_eq!(options.fragmentVariableSuffix, "Frag");
+}
+
+// -- dedupeOperationSuffix / omitOperationSuffix tests --
+// These only affect fragment variable names, matching codegen's
+// getFragmentVariableName behavior.
+
+fn get_test_code_visitor_dedupe_suffix() -> GraphQLVisitor {
+    GraphQLVisitor::new(GraphQLCodegenOptions {
+        filename: "test.ts".to_string(),
+        cwd: "/home/faketestproject".to_string(),
+        artifact_directory: "./src/gql".to_string(),
+        gql_tag_name: "gql".to_string(),
+        naming_convention: "change-case-all#pascalCase".to_string(),
+        document_variable_prefix: "".to_string(),
+        document_variable_suffix: "Document".to_string(),
+        fragment_variable_prefix: "".to_string(),
+        fragment_variable_suffix: "FragmentDoc".to_string(),
+        dedupe_operation_suffix: true,
+        omit_operation_suffix: false,
+    })
+}
+
+fn get_test_code_visitor_omit_suffix() -> GraphQLVisitor {
+    GraphQLVisitor::new(GraphQLCodegenOptions {
+        filename: "test.ts".to_string(),
+        cwd: "/home/faketestproject".to_string(),
+        artifact_directory: "./src/gql".to_string(),
+        gql_tag_name: "gql".to_string(),
+        naming_convention: "change-case-all#pascalCase".to_string(),
+        document_variable_prefix: "".to_string(),
+        document_variable_suffix: "Document".to_string(),
+        fragment_variable_prefix: "".to_string(),
+        fragment_variable_suffix: "FragmentDoc".to_string(),
+        dedupe_operation_suffix: false,
+        omit_operation_suffix: true,
+    })
+}
+
+// Fragment name ends with "Fragment" and suffix starts with "Fragment" →
+// dedupe strips overlapping "Fragment" from the suffix, leaving just "Doc".
+// So MyFragment → MyFragmentDoc (not MyFragmentFragmentDoc).
+test!(
+    Default::default(),
+    |_| visit_mut_pass(get_test_code_visitor_dedupe_suffix()),
+    dedupe_strips_overlapping_fragment_suffix,
+    r#"import gql from "gql-tag";
+
+const MyFragment = gql(`
+  fragment MyFragment on User {
+    id
+    name
+  }
+`);"#
+);
+
+// Fragment name does NOT end with "Fragment" → dedupe has no effect,
+// suffix is appended normally.
+test!(
+    Default::default(),
+    |_| visit_mut_pass(get_test_code_visitor_dedupe_suffix()),
+    dedupe_no_effect_when_name_does_not_end_with_fragment,
+    r#"import gql from "gql-tag";
+
+const UserFields = gql(`
+  fragment UserFields on User {
+    id
+    name
+  }
+`);"#
+);
+
+// dedupeOperationSuffix should NOT affect operation document variables
+test!(
+    Default::default(),
+    |_| visit_mut_pass(get_test_code_visitor_dedupe_suffix()),
+    dedupe_does_not_affect_operation_document_variable,
+    r#"import gql from "gql-tag";
+
+const GetUserQuery = gql(`
+  query GetUserQuery {
+    user {
+      id
+    }
+  }
+`);"#
+);
+
+// omitOperationSuffix → fragment suffix becomes empty
+test!(
+    Default::default(),
+    |_| visit_mut_pass(get_test_code_visitor_omit_suffix()),
+    omit_suffix_removes_fragment_suffix,
+    r#"import gql from "gql-tag";
+
+const MyFragment = gql(`
+  fragment MyFragment on User {
+    id
+    name
+  }
+`);"#
+);
+
+// omitOperationSuffix should NOT affect operation document variables
+test!(
+    Default::default(),
+    |_| visit_mut_pass(get_test_code_visitor_omit_suffix()),
+    omit_suffix_does_not_affect_operation_document_variable,
+    r#"import gql from "gql-tag";
+
+const GetUser = gql(`
+  query GetUser {
+    user {
+      id
+    }
+  }
+`);"#
+);
+
+// When both flags are set, omit takes precedence (suffix is empty)
+fn get_test_code_visitor_omit_and_dedupe() -> GraphQLVisitor {
+    GraphQLVisitor::new(GraphQLCodegenOptions {
+        filename: "test.ts".to_string(),
+        cwd: "/home/faketestproject".to_string(),
+        artifact_directory: "./src/gql".to_string(),
+        gql_tag_name: "gql".to_string(),
+        naming_convention: "change-case-all#pascalCase".to_string(),
+        document_variable_prefix: "".to_string(),
+        document_variable_suffix: "Document".to_string(),
+        fragment_variable_prefix: "".to_string(),
+        fragment_variable_suffix: "FragmentDoc".to_string(),
+        dedupe_operation_suffix: true,
+        omit_operation_suffix: true,
+    })
+}
+
+test!(
+    Default::default(),
+    |_| visit_mut_pass(get_test_code_visitor_omit_and_dedupe()),
+    omit_takes_precedence_over_dedupe,
+    r#"import gql from "gql-tag";
+
+const MyFragment = gql(`
+  fragment MyFragment on User {
+    id
+    name
+  }
+`);"#
+);
+
+#[test]
+fn plugin_options_dedupe_and_omit_default_to_false() {
+    let options: PluginOptions = serde_json::from_str(
+        r#"{"artifactDirectory":"./src/gql"}"#,
+    )
+    .unwrap();
+
+    assert!(!options.dedupeOperationSuffix);
+    assert!(!options.omitOperationSuffix);
+}
+
+#[test]
+fn plugin_options_accept_dedupe_and_omit_values() {
+    let options: PluginOptions = serde_json::from_str(
+        r#"{
+            "artifactDirectory":"./src/gql",
+            "dedupeOperationSuffix": true,
+            "omitOperationSuffix": true
+        }"#,
+    )
+    .unwrap();
+
+    assert!(options.dedupeOperationSuffix);
+    assert!(options.omitOperationSuffix);
+}
 
 #[test]
 fn naming_convention_keep_preserves_original_name() {

--- a/contrib/graphql-codegen-client-preset/tests/__swc_snapshots__/src/tests.rs/custom_document_suffix.js
+++ b/contrib/graphql-codegen-client-preset/tests/__swc_snapshots__/src/tests.rs/custom_document_suffix.js
@@ -1,0 +1,3 @@
+import { GetUserDoc } from "./src/gql/graphql";
+import gql from "gql-tag";
+const GetUser = GetUserDoc;

--- a/contrib/graphql-codegen-client-preset/tests/__swc_snapshots__/src/tests.rs/custom_fragment_suffix.js
+++ b/contrib/graphql-codegen-client-preset/tests/__swc_snapshots__/src/tests.rs/custom_fragment_suffix.js
@@ -1,0 +1,3 @@
+import { UserFieldsFrag } from "./src/gql/graphql";
+import gql from "gql-tag";
+const UserFields = UserFieldsFrag;

--- a/contrib/graphql-codegen-client-preset/tests/__swc_snapshots__/src/tests.rs/dedupe_does_not_affect_operation_document_variable.js
+++ b/contrib/graphql-codegen-client-preset/tests/__swc_snapshots__/src/tests.rs/dedupe_does_not_affect_operation_document_variable.js
@@ -1,0 +1,3 @@
+import { GetUserQueryDocument } from "./src/gql/graphql";
+import gql from "gql-tag";
+const GetUserQuery = GetUserQueryDocument;

--- a/contrib/graphql-codegen-client-preset/tests/__swc_snapshots__/src/tests.rs/dedupe_no_effect_when_name_does_not_end_with_fragment.js
+++ b/contrib/graphql-codegen-client-preset/tests/__swc_snapshots__/src/tests.rs/dedupe_no_effect_when_name_does_not_end_with_fragment.js
@@ -1,0 +1,3 @@
+import { UserFieldsFragmentDoc } from "./src/gql/graphql";
+import gql from "gql-tag";
+const UserFields = UserFieldsFragmentDoc;

--- a/contrib/graphql-codegen-client-preset/tests/__swc_snapshots__/src/tests.rs/dedupe_strips_overlapping_fragment_suffix.js
+++ b/contrib/graphql-codegen-client-preset/tests/__swc_snapshots__/src/tests.rs/dedupe_strips_overlapping_fragment_suffix.js
@@ -1,0 +1,3 @@
+import { MyFragmentDoc } from "./src/gql/graphql";
+import gql from "gql-tag";
+const MyFragment = MyFragmentDoc;

--- a/contrib/graphql-codegen-client-preset/tests/__swc_snapshots__/src/tests.rs/document_variable_prefix_applied.js
+++ b/contrib/graphql-codegen-client-preset/tests/__swc_snapshots__/src/tests.rs/document_variable_prefix_applied.js
@@ -1,0 +1,3 @@
+import { GqlGetUser } from "./src/gql/graphql";
+import gql from "gql-tag";
+const GetUser = GqlGetUser;

--- a/contrib/graphql-codegen-client-preset/tests/__swc_snapshots__/src/tests.rs/empty_document_suffix_uses_operation_name_directly.js
+++ b/contrib/graphql-codegen-client-preset/tests/__swc_snapshots__/src/tests.rs/empty_document_suffix_uses_operation_name_directly.js
@@ -1,0 +1,3 @@
+import { GetUser } from "./src/gql/graphql";
+import gql from "gql-tag";
+const GetUser = GetUser;

--- a/contrib/graphql-codegen-client-preset/tests/__swc_snapshots__/src/tests.rs/omit_suffix_does_not_affect_operation_document_variable.js
+++ b/contrib/graphql-codegen-client-preset/tests/__swc_snapshots__/src/tests.rs/omit_suffix_does_not_affect_operation_document_variable.js
@@ -1,0 +1,3 @@
+import { GetUserDocument } from "./src/gql/graphql";
+import gql from "gql-tag";
+const GetUser = GetUserDocument;

--- a/contrib/graphql-codegen-client-preset/tests/__swc_snapshots__/src/tests.rs/omit_suffix_removes_fragment_suffix.js
+++ b/contrib/graphql-codegen-client-preset/tests/__swc_snapshots__/src/tests.rs/omit_suffix_removes_fragment_suffix.js
@@ -1,0 +1,3 @@
+import { MyFragment } from "./src/gql/graphql";
+import gql from "gql-tag";
+const MyFragment = MyFragment;

--- a/contrib/graphql-codegen-client-preset/tests/__swc_snapshots__/src/tests.rs/omit_takes_precedence_over_dedupe.js
+++ b/contrib/graphql-codegen-client-preset/tests/__swc_snapshots__/src/tests.rs/omit_takes_precedence_over_dedupe.js
@@ -1,0 +1,3 @@
+import { MyFragment } from "./src/gql/graphql";
+import gql from "gql-tag";
+const MyFragment = MyFragment;


### PR DESCRIPTION
Close #610

Adds missing config options matching `@graphql-codegen/client-preset`:

  | Option | Default |
  |--------|---------|
  | `documentVariablePrefix` | `""` |
  | `documentVariableSuffix` | `"Document"` |
  | `fragmentVariablePrefix` | `""` |
  | `fragmentVariableSuffix` | `"FragmentDoc"` |
  | `dedupeOperationSuffix` | `false` |
  | `omitOperationSuffix` | `false` |

`dedupeOperationSuffix` and `omitOperationSuffix` only affect fragment variable names, matching upstream codegen's `getFragmentVariableName`  behavior in [`base-visitor.ts`](https://github.com/dotansimha/graphql-code-generator/blob/f9e4842/packages/plugins/other/visitor-plugin-common/src/base-visitor.ts#L507-L529).

All defaults match the previous hardcoded values.