### PR TITLE
fix(styled-components): strip line comments after multiline declarations

### DIFF
--- a/packages/styled-components/__tests__/__snapshots__/wasm.test.ts.snap
+++ b/packages/styled-components/__tests__/__snapshots__/wasm.test.ts.snap
@@ -503,6 +503,20 @@ const Div = styled.div.withConfig({
 "
 `;
 
+exports[`Should load styled-components wasm plugin correctly > Should transform issue-615 correctly 1`] = `
+"import styled from "styled-components";
+const someVariable1 = "10px";
+const someVariable2 = "20px";
+const someVariable3 = "30px";
+const MyStyledComponent = styled.div([
+    \`max-height:calc( \`,
+    \` + \`,
+    \` + \`,
+    \` );\`
+], someVariable1, someVariable2, someVariable3);
+"
+`;
+
 exports[`Should load styled-components wasm plugin correctly > Should transform minify-css-in-helpers correctly 1`] = `
 "import { createGlobalStyle, css, keyframes } from "styled-components";
 const key = keyframes\`to{transform:rotate(360deg);}\`;

--- a/packages/styled-components/transform/src/visitors/minify/css.rs
+++ b/packages/styled-components/transform/src/visitors/minify/css.rs
@@ -65,7 +65,7 @@ fn strip_line_comment(line: impl AsRef<str>) -> String {
         !s.ends_with(':') // NOTE: This is another guard against urls, if they're not inside strings or parantheses.
             && count_occurrences(s, '\'') % 2 == 0
             && count_occurrences(s, '"') % 2 == 0
-            && count_occurrences(s, '(') == count_occurrences(s, ')')
+            && count_occurrences(s, '(') <= count_occurrences(s, ')')
     })
 }
 
@@ -191,6 +191,13 @@ mod tests {
         assert_eq!(
             strip_line_comment(r#"https://test.com// comment//"#),
             r#"https://test.com"#
+        );
+
+        // strips comments after multiline declarations compacted onto a closing
+        // paren line
+        assert_eq!(
+            strip_line_comment(r#"      ); // this is axaBlue with a 5% white mix"#),
+            r#"      ); "#
         );
     }
 

--- a/packages/styled-components/transform/tests/fixtures/issue-615/code.js
+++ b/packages/styled-components/transform/tests/fixtures/issue-615/code.js
@@ -1,0 +1,11 @@
+import styled from "styled-components";
+
+const someVariable1 = "10px";
+const someVariable2 = "20px";
+const someVariable3 = "30px";
+
+const MyStyledComponent = styled.div`
+  max-height: calc(
+    ${someVariable1} + ${someVariable2} + ${someVariable3}
+  ); // This comment causes a parsing error
+`;

--- a/packages/styled-components/transform/tests/fixtures/issue-615/config.json
+++ b/packages/styled-components/transform/tests/fixtures/issue-615/config.json
@@ -1,0 +1,4 @@
+{
+  "ssr": false,
+  "displayName": false
+}

--- a/packages/styled-components/transform/tests/fixtures/issue-615/output.js
+++ b/packages/styled-components/transform/tests/fixtures/issue-615/output.js
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+const someVariable1 = "10px";
+const someVariable2 = "20px";
+const someVariable3 = "30px";
+const MyStyledComponent = styled.div([
+    `max-height:calc( `,
+    ` + `,
+    ` + `,
+    ` );`
+], someVariable1, someVariable2, someVariable3);


### PR DESCRIPTION
## Summary

- Fix styled-components CSS minification so `//` comments after multiline declarations are stripped when the line starts with closing parens.
- Preserve the existing URL, string, and still-open-paren guards for inline `//` handling.
- Add issue #615 regression coverage for the Rust fixture suite and WASM snapshot.

Fixes #615.

## Validation

- `cargo test -p styled_components --lib`
- `cargo test -p styled_components --test fixture issue_615 -- --include-ignored`
- `pnpm exec vitest run --testTimeout=0`
- `cargo fmt -p styled_components --check`