### PR TITLE
chore: release changed plugins

### DIFF
--- a/.changeset/fix-formatjs-issue-604.md
+++ b/.changeset/fix-formatjs-issue-604.md
@@ -1,7 +1,0 @@
----
-"@swc/plugin-formatjs": patch
----
-
-Avoid hygiene proxy crashes by evaluating only static formatjs descriptor values.
-The legacy Rust visitor constructor now ignores its evaluator argument; use
-`create_formatjs_visitor_without_evaluator` for new integrations.

--- a/packages/formatjs/CHANGELOG.md
+++ b/packages/formatjs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @swc/plugin-formatjs
 
+## 9.12.1
+
+### Patch Changes
+
+- c5bd878: Avoid hygiene proxy crashes by evaluating only static formatjs descriptor values.
+  The legacy Rust visitor constructor now ignores its evaluator argument; use
+  `create_formatjs_visitor_without_evaluator` for new integrations.
+
 ## 9.12.0
 
 ### Minor Changes

--- a/packages/formatjs/README.md
+++ b/packages/formatjs/README.md
@@ -95,6 +95,14 @@ Will extract the metadata: `{project: "web", locale: "en", region: "us"}` that g
 
 # @swc/plugin-formatjs
 
+## 9.12.1
+
+### Patch Changes
+
+- c5bd878: Avoid hygiene proxy crashes by evaluating only static formatjs descriptor values.
+  The legacy Rust visitor constructor now ignores its evaluator argument; use
+  `create_formatjs_visitor_without_evaluator` for new integrations.
+
 ## 9.12.0
 
 ### Minor Changes

--- a/packages/formatjs/package.json
+++ b/packages/formatjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-formatjs",
-  "version": "9.12.0",
+  "version": "9.12.1",
   "publishConfig": {
     "access": "public",
     "provenance": true

--- a/packages/styled-components/CHANGELOG.md
+++ b/packages/styled-components/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @swc/plugin-styled-components
 
+## 12.12.1
+
+### Patch Changes
+
+- Strip trailing line comments after multiline styled-components declarations during CSS minification.
+
 ## 12.12.0
 
 ### Minor Changes

--- a/packages/styled-components/README.md
+++ b/packages/styled-components/README.md
@@ -30,6 +30,12 @@ Then update your `.swcrc` file like below:
 
 # @swc/plugin-styled-components
 
+## 12.12.1
+
+### Patch Changes
+
+- Strip trailing line comments after multiline styled-components declarations during CSS minification.
+
 ## 12.12.0
 
 ### Minor Changes

--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/plugin-styled-components",
-  "version": "12.12.0",
+  "version": "12.12.1",
   "publishConfig": {
     "access": "public",
     "provenance": true


### PR DESCRIPTION
## Summary
- Release `@swc/plugin-formatjs` as `9.12.1` from the existing formatjs patch changeset.
- Release `@swc/plugin-styled-components` as `12.12.1` so the post-#622 styled-components fix gets a new npm artifact.

## Why
The latest publish workflow after #625 completed with no new packages because the affected plugin package versions had not been bumped. This PR only updates release metadata so the next main publish has new package versions to publish.

## Validation
- Confirmed `@swc/plugin-formatjs@9.12.1` is not on npm.
- Confirmed `@swc/plugin-styled-components@12.12.1` is not on npm.
- `pnpm -F @swc/plugin-formatjs test`
- `pnpm -F @swc/plugin-styled-components test`