### PR TITLE
📝 docs(graphql-codegen-client-preset): monorepo paths

### DIFF
--- a/contrib/graphql-codegen-client-preset/README.md
+++ b/contrib/graphql-codegen-client-preset/README.md
@@ -53,6 +53,22 @@ const nextConfig = {
 };
 ```
 
+> **Monorepos:** Next.js uses [Turbopack's workspace root](https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopack#root-directory) — the directory containing your lockfile (`yarn.lock`, `pnpm-lock.yaml`, etc.) — as the SWC `cwd`. If your Next app lives below that root, write `artifactDirectory` as a path from the workspace root down to the codegen output, not as a path relative to the Next app:
+
+```ts
+// apps/web/next.config.mjs, in a Turborepo where yarn.lock sits at the repo root
+const nextConfig = {
+  experimental: {
+    swcPlugins: [
+      [
+        "@swc-contrib/plugin-graphql-codegen-client-preset",
+        { artifactDirectory: "apps/web/src/gql", gqlTagName: "graphql" },
+      ],
+    ],
+  },
+};
+```
+
 #### `.swcrc`
 
 ```json5


### PR DESCRIPTION
# Problem Statement

In a Turborepo / pnpm workspace where the Next.js app lives below the workspace root, the README's Next.js example resolves `artifactDirectory` against the workspace root rather than the Next app directory. The build then fails with:

```
Module not found: Can't resolve './../../../../src/gql/graphql'
```

and the artifact path is not an obvious cause from the error message.

Root cause: Next.js sets the SWC plugin's `cwd` to [Turbopack's workspace root](https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopack#root-directory) (the directory containing the lockfile). The plugin joins relative `artifactDirectory` values onto that `cwd`, so `"./src/gql"` lands at `<workspace-root>/src/gql` instead of `<workspace-root>/apps/web/src/gql`.

Reproduced with Next 16.2.6 + Turbopack + Yarn workspaces, plugin 0.24.0.

# Solution

Add a callout under the Next.js section explaining the workspace-root anchoring, plus a copy-pasteable Turborepo example with `artifactDirectory: "apps/web/src/gql"`. Docs only.

# Test Plan

Verified the new config snippet end-to-end in a Turborepo (Yarn 4 workspaces, Next 16.2.6 + Turbopack, plugin 0.24.0): with the workspace-root-relative `artifactDirectory`, the build succeeds and the resulting chunks no longer contain the GraphQL operation strings (tree-shaking works as the plugin advertises).

---
_PR summary authored by Claude Code (Opus 4.7) on behalf of the author._
