### PR TITLE
fix(emotion): Handle React Compiler output without panicking

### DIFF
--- a/.changeset/quiet-emotion-spans.md
+++ b/.changeset/quiet-emotion-spans.md
@@ -1,0 +1,5 @@
+---
+"@swc/plugin-emotion": patch
+---
+
+Handle React Compiler output with synthetic spans.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.1",
-    "@swc/core": "^1.15.40",
+    "@swc/core": "^1.15.43",
     "@taplo/cli": "^0.7.0",
     "@types/node": "^22.13.9",
     "husky": "^9.0.11",

--- a/packages/emotion/__tests__/wasm.test.ts
+++ b/packages/emotion/__tests__/wasm.test.ts
@@ -123,3 +123,37 @@ test("Should keep plain keyframes label for namespace imports", async () => {
   );
   expect(output.code).not.toContain("label:pulse");
 });
+
+test("Should transform css prop output from React Compiler", async () => {
+  const output = await transform(
+    `
+      import { css } from "@emotion/react";
+
+      export function App() {
+        return <div css={css\`width:120px;\`} />;
+      }
+    `,
+    {
+      envName: "development",
+      filename: "percentInput.tsx",
+      jsc: {
+        parser: {
+          syntax: "typescript",
+          tsx: true,
+        },
+        transform: {
+          react: {
+            runtime: "automatic",
+            importSource: "@emotion/react",
+          },
+          reactCompiler: true,
+        },
+        experimental: {
+          plugins: [[pluginPath, {}]],
+        },
+      },
+    } satisfies Options,
+  );
+
+  expect(output.code).toContain('css("width:120px;", "")');
+});

--- a/packages/emotion/__tests__/wasm.test.ts
+++ b/packages/emotion/__tests__/wasm.test.ts
@@ -135,11 +135,10 @@ test("Should transform css prop output from React Compiler", async () => {
     `,
     {
       envName: "development",
-      filename: "percentInput.tsx",
       jsc: {
         parser: {
-          syntax: "typescript",
-          tsx: true,
+          syntax: "ecmascript",
+          jsx: true,
         },
         transform: {
           react: {

--- a/packages/emotion/src/lib.rs
+++ b/packages/emotion/src/lib.rs
@@ -4,7 +4,9 @@ use std::path::Path;
 
 use serde::Deserialize;
 use swc_atoms::{atom, Atom};
-use swc_common::{plugin::metadata::TransformPluginMetadataContextKind, SourceMapper, Spanned};
+use swc_common::{
+    plugin::metadata::TransformPluginMetadataContextKind, BytePos, SourceMapper, Spanned,
+};
 use swc_ecma_ast::Program;
 use swc_emotion::EmotionOptions;
 use swc_plugin_macro::plugin_transform;
@@ -70,8 +72,12 @@ pub fn process_transform(program: Program, data: TransformPluginProgramMetadata)
         .unwrap_or_default();
     let path = Path::new(&file_name);
     let source_map = std::sync::Arc::new(data.source_map);
-    let pos = source_map.lookup_char_pos(program.span().lo);
-    let hash = pos.file.src_hash() as u32;
+    let hash = if program.span().lo == BytePos(0) {
+        0
+    } else {
+        let pos = source_map.lookup_char_pos(program.span().lo);
+        pos.file.src_hash() as u32
+    };
     program.apply(swc_emotion::emotion(
         &config,
         path,

--- a/packages/emotion/src/lib.rs
+++ b/packages/emotion/src/lib.rs
@@ -4,9 +4,7 @@ use std::path::Path;
 
 use serde::Deserialize;
 use swc_atoms::{atom, Atom};
-use swc_common::{
-    plugin::metadata::TransformPluginMetadataContextKind, BytePos, SourceMapper, Spanned,
-};
+use swc_common::{plugin::metadata::TransformPluginMetadataContextKind, SourceMapper, Spanned};
 use swc_ecma_ast::Program;
 use swc_emotion::EmotionOptions;
 use swc_plugin_macro::plugin_transform;
@@ -72,12 +70,8 @@ pub fn process_transform(program: Program, data: TransformPluginProgramMetadata)
         .unwrap_or_default();
     let path = Path::new(&file_name);
     let source_map = std::sync::Arc::new(data.source_map);
-    let hash = if program.span().lo == BytePos(0) {
-        0
-    } else {
-        let pos = source_map.lookup_char_pos(program.span().lo);
-        pos.file.src_hash() as u32
-    };
+    let pos = source_map.lookup_char_pos(program.span().lo);
+    let hash = pos.file.src_hash() as u32;
     program.apply(swc_emotion::emotion(
         &config,
         path,

--- a/packages/emotion/transform/src/lib.rs
+++ b/packages/emotion/transform/src/lib.rs
@@ -258,6 +258,14 @@ impl<'a, C: Comments> EmotionTransformer<'a, C> {
         label
     }
 
+    fn add_pure_comment(&self, pos: BytePos) {
+        // React Compiler can synthesize Emotion calls with dummy spans.
+        // SWC cannot attach comments at BytePos(0), so skip the hint there.
+        if pos != BytePos(0) {
+            self.comments.add_pure_comment(pos);
+        }
+    }
+
     fn create_call_label_arg(&self, kind: ExprKind) -> ExprOrSpread {
         self.create_runtime_label(kind, false).as_arg()
     }
@@ -267,6 +275,10 @@ impl<'a, C: Comments> EmotionTransformer<'a, C> {
     }
 
     fn create_sourcemap(&mut self, pos: BytePos) -> Option<String> {
+        if pos == BytePos(0) {
+            return None;
+        }
+
         if self.options.sourcemap.unwrap_or(false) {
             let loc = self.cm.get_code_map().lookup_char_pos(pos);
             let filename = self.filepath.to_str().map(BytesStr::from_str_slice);
@@ -527,7 +539,7 @@ impl<'a, C: Comments> EmotionTransformer<'a, C> {
                     args.push(cm.as_arg());
                 }
 
-                self.comments.add_pure_comment(expr_pos);
+                self.add_pure_comment(expr_pos);
                 let call_span = Span::new(expr_pos, expr_pos);
 
                 let callee = match &css_callee {
@@ -582,7 +594,7 @@ impl<C: Comments> Fold for EmotionTransformer<'_, C> {
                                 if matches!(*kind, ExprKind::Css | ExprKind::Keyframes)
                                     && !self.in_jsx_element
                                 {
-                                    self.comments.add_pure_comment(expr.span.lo());
+                                    self.add_pure_comment(expr.span.lo());
                                     if self.options.auto_label.unwrap_or(false) {
                                         expr.args.push(self.create_call_label_arg(*kind));
                                     }
@@ -608,7 +620,7 @@ impl<C: Comments> Fold for EmotionTransformer<'_, C> {
                                 if !c.args.is_empty() {
                                     let mut args_props = Vec::with_capacity(2);
                                     args_props.push(self.create_label_prop_node("target"));
-                                    self.comments.add_pure_comment(expr.span.lo());
+                                    self.add_pure_comment(expr.span.lo());
                                     if self.options.auto_label.unwrap_or(false) {
                                         args_props.push(PropOrSpread::Prop(Box::new(
                                             Prop::KeyValue(KeyValueProp {
@@ -678,7 +690,7 @@ impl<C: Comments> Fold for EmotionTransformer<'_, C> {
                                         args_props.push(self.create_label_prop_node("target"));
                                         let mut args = vec![prop.sym.as_ref().as_arg()];
                                         if !self.in_jsx_element {
-                                            self.comments.add_pure_comment(expr.span.lo());
+                                            self.add_pure_comment(expr.span.lo());
                                             if self.options.auto_label.unwrap_or(false) {
                                                 args_props.push(PropOrSpread::Prop(Box::new(
                                                     Prop::KeyValue(KeyValueProp {
@@ -724,7 +736,7 @@ impl<C: Comments> Fold for EmotionTransformer<'_, C> {
                                     .iter()
                                     .find_map(|item| match_runtime_export(item, &m.prop))
                                 {
-                                    self.comments.add_pure_comment(expr.span.lo());
+                                    self.add_pure_comment(expr.span.lo());
                                     if self.options.auto_label.unwrap_or(false) {
                                         expr.args.push(self.create_call_label_arg(kind));
                                     }
@@ -787,7 +799,7 @@ impl<C: Comments> Fold for EmotionTransformer<'_, C> {
                                 let mut callee = call.take();
                                 let mut object_props = Vec::with_capacity(2);
                                 object_props.push(self.create_label_prop_node("target"));
-                                self.comments.add_pure_comment(callee.span.lo());
+                                self.add_pure_comment(callee.span.lo());
                                 if self.options.auto_label.unwrap_or(false) {
                                     object_props.push(PropOrSpread::Prop(Box::new(
                                         Prop::KeyValue(KeyValueProp {
@@ -864,7 +876,7 @@ impl<C: Comments> Fold for EmotionTransformer<'_, C> {
                         if matches!(*kind, ExprKind::Css | ExprKind::Keyframes) {
                             let mut args = self.create_args_from_tagged_tpl(&mut tagged_tpl.tpl);
                             if !self.in_jsx_element {
-                                self.comments.add_pure_comment(i.span.lo());
+                                self.add_pure_comment(i.span.lo());
                                 if self.options.auto_label.unwrap_or(false) {
                                     args.push(self.create_tagged_tpl_label_arg(*kind));
                                 }
@@ -911,7 +923,7 @@ impl<C: Comments> Fold for EmotionTransformer<'_, C> {
                                             args.push(cm.as_arg());
                                         }
 
-                                        self.comments.add_pure_comment(member_expr.span.lo());
+                                        self.add_pure_comment(member_expr.span.lo());
                                         return Expr::Call(CallExpr {
                                             callee: CallExpr {
                                                 callee: i.take().as_callee(),
@@ -935,7 +947,7 @@ impl<C: Comments> Fold for EmotionTransformer<'_, C> {
                                     if let Some(kind) = c.exported_names.iter().find_map(|item| {
                                         match_runtime_export(item, &member_expr.prop)
                                     }) {
-                                        self.comments.add_pure_comment(member_expr.span.lo());
+                                        self.add_pure_comment(member_expr.span.lo());
                                         return Expr::Call(CallExpr {
                                             callee: member_expr.take().as_callee(),
                                             args: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^2.27.1
         version: 2.28.0
       '@swc/core':
-        specifier: ^1.15.40
-        version: 1.15.40
+        specifier: ^1.15.43
+        version: 1.15.43
       '@taplo/cli':
         specifier: ^0.7.0
         version: 0.7.0
@@ -761,8 +761,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@swc/core-darwin-arm64@1.15.40':
-    resolution: {integrity: sha512-PaYyclfmQ++77D8ityYvmmVzHv9aG8ROwt2GfG6/ccloy4Hgf80qtOnzb9VYvPsUT7Ty1uhuDRhv3XYpf62qhQ==}
+  '@swc/core-darwin-arm64@1.15.43':
+    resolution: {integrity: sha512-v1aVuvXdo/BHxJzco9V2xpHrvwWmhfS8t6gziY5wJxd+Z2h8AeJRnAwPD8itCDaGXVBwJ/CaKfxEzTkG0Va0OA==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [darwin]
@@ -773,8 +773,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@swc/core-darwin-x64@1.15.40':
-    resolution: {integrity: sha512-HbbPzvfLBUXjIB1Ezks+//lNUjmLjfyd63XSwprJgrZaXYdm70kohXPJUWdqKZozolFxbPaO+xtBaiUp6BoueA==}
+  '@swc/core-darwin-x64@1.15.43':
+    resolution: {integrity: sha512-lp3d4Lamc8dt5huYdGLSR+9hLxmfr1jb0l+4XXG2zPqZwYWRN9R0U2qYoTrggiU2RWW0oV9VbWM3kBnqIc2kdQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [darwin]
@@ -785,8 +785,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@swc/core-linux-arm-gnueabihf@1.15.40':
-    resolution: {integrity: sha512-SlRZsCjOCPR2LvFs0Ri/Xrx/5o5TCt8vl4gW6mX1hEZOG0a625RxzRHpHdAQNGykmAN/7IeaFAJG+QnNmxlHcA==}
+  '@swc/core-linux-arm-gnueabihf@1.15.43':
+    resolution: {integrity: sha512-JWTQQELtsG5GgphDrr/XqqmM2pDN3cZqbMS0Mrg+iTiXL3F74sn/S2IyYE/5u4h2KLkTf9qQ7dXyxsbx7YzkeA==}
     engines: {node: '>=10'}
     cpu: [arm]
     os: [linux]
@@ -797,8 +797,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@swc/core-linux-arm64-gnu@1.15.40':
-    resolution: {integrity: sha512-Q8byxJt2fh8CR3EUX6snBpy47AoBVm+In/+Z3rjDHMjC38ZvR9/gtUUNCT0tfrn4EdVsO8/QPi59nxrxvqxvBQ==}
+  '@swc/core-linux-arm64-gnu@1.15.43':
+    resolution: {integrity: sha512-B4otJRdPWIsmiSBf0uG7Z/+vMWmkufjz5MmYxubwKuZazDW14Zd3symga1N62QR4RT+kEFeHEgsXfZGyn/w0hw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
@@ -809,20 +809,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@swc/core-linux-arm64-musl@1.15.40':
-    resolution: {integrity: sha512-4z0MgHU+7M0pZDqBN1El7mFXDI1SBwinfcUkAyA4v8QrhOIUOZltySt2aStQLZGrdXVXM4Y4ylfiTC04ED+MoQ==}
+  '@swc/core-linux-arm64-musl@1.15.43':
+    resolution: {integrity: sha512-6zB6OnpViBxYy4tgY3v2i6AZY9fwkcHZ032UOwtwUuW1d19sdT07qF0kZe6/3UR1tUaK6jjg2rmVcUIBCEYVjQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
 
-  '@swc/core-linux-ppc64-gnu@1.15.40':
-    resolution: {integrity: sha512-fLI4iUgeSZu0eRWUXwe6YzPFx9gHbFiPkl8Rp3mJfP8OpNR3nTQCGPvHdDh9xniW7mVvgMY4ni7A4VzqI1KrpA==}
+  '@swc/core-linux-ppc64-gnu@1.15.43':
+    resolution: {integrity: sha512-coxE1ZWdB3uSDVNoEtYNrRi/1epvckZx9cTJ8ICUxTMTxGk+yvQ/Twacp3ruZSaMPGCriUjP86C37VhaT6nyRg==}
     engines: {node: '>=10'}
     cpu: [ppc64]
     os: [linux]
 
-  '@swc/core-linux-s390x-gnu@1.15.40':
-    resolution: {integrity: sha512-YqeKMAb7d4nQSGMJQ454IlaCENpzcDqhvBE9+CPfdnYpnUXxd+BSrB6Xk0YjW8UyoEhUj4p6quATCxbsp6J3jg==}
+  '@swc/core-linux-s390x-gnu@1.15.43':
+    resolution: {integrity: sha512-lXfLhs+LpBsD5inuYx+YDH5WsPPBQ95KPUiy8P5wq9ob9xKDZFqwNfU2QW6bGO8NqRO/H9JQomTSt5Yyh+FGfA==}
     engines: {node: '>=10'}
     cpu: [s390x]
     os: [linux]
@@ -833,8 +833,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@swc/core-linux-x64-gnu@1.15.40':
-    resolution: {integrity: sha512-7HOuS1iGcme/j/TuL1TfmmLGiMQrjv/GmjyZeydl00FKPtpGXEldwqfI56xgd1YzrzoB2svWjxbGGyQ0TEASxg==}
+  '@swc/core-linux-x64-gnu@1.15.43':
+    resolution: {integrity: sha512-07XnKwTmKy8TGOZG3D9fRnLWGynxPjwQnZLVmBFbo6F+7vHYzBIOuwXEhemrChBWb6yDNZsVCcMWCPX6FDD2xg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
@@ -845,8 +845,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@swc/core-linux-x64-musl@1.15.40':
-    resolution: {integrity: sha512-h4kZYHc7dpc9P9u4brRJaS8Pl7tPVHAeiLSzw7T5RfIJgAoSdaCMKzI/2Uay9gFhaw8uyCDl0L5q37r0EpAfIA==}
+  '@swc/core-linux-x64-musl@1.15.43':
+    resolution: {integrity: sha512-TJc+bsSIaBh+hZvZ5GRtW/K1bw66TJ9vsUwvVIsZdiWxU5ObLwZvfcnZ3UpgVfMnFibRes9uriJrQNBHEEogRQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
@@ -857,8 +857,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@swc/core-win32-arm64-msvc@1.15.40':
-    resolution: {integrity: sha512-+mQgKZXSj6mV38Zh05QaxSjUDmGP/R2JWlXZTDLSPkDzHU6p3GxN9eeSf5dfyDVU86946fmCvSzyl/ucImx8+A==}
+  '@swc/core-win32-arm64-msvc@1.15.43':
+    resolution: {integrity: sha512-jfd7s2/bUQYkOHLs+LWQNKZdmDa8+sufKLllhpWAhVQ2GDCwsHe3vR/j+OSiItZNtkzFuaawa3+SAKz9y5gYfw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [win32]
@@ -869,8 +869,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@swc/core-win32-ia32-msvc@1.15.40':
-    resolution: {integrity: sha512-yvwdPLGd25mcj/mNatjNQ0lZujtQD6psH3v9PNmMb+fSzjbNG8KIDxjFWrcV+fsFVLOkyOmdJsFmX7NAFjVyPw==}
+  '@swc/core-win32-ia32-msvc@1.15.43':
+    resolution: {integrity: sha512-rLAE8JvucqEW1ZGohxPQrQWPBQeJG4+ypKbWfdlU/qmKScvCkxf9/Jxnzki1dkUQCQ7P5Enp13RlvqOlvx/32g==}
     engines: {node: '>=10'}
     cpu: [ia32]
     os: [win32]
@@ -881,8 +881,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@swc/core-win32-x64-msvc@1.15.40':
-    resolution: {integrity: sha512-OXtKsLU1bVtInzzDEAY2sYiF/rl4tvAnLLLpuMp3HzAOQZ5A+i69AKDhA1YLQTaMAqO3vzyYNVAYVRMPtSYD4w==}
+  '@swc/core-win32-x64-msvc@1.15.43':
+    resolution: {integrity: sha512-h8MLDHZcfIukwQWj03rIJZx1I0E81AYj2X7J/nGErG4nz+QAv6G1Z+peotvinL3lqpbo32tLYSMFo32/ySzxKg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [win32]
@@ -896,8 +896,8 @@ packages:
       '@swc/helpers':
         optional: true
 
-  '@swc/core@1.15.40':
-    resolution: {integrity: sha512-2kwzJikRvgtNAG7MwVZY2vEzZjTxKIq5jXOihuSV/8U+Hej8Va22t65aKnJZs3P+NwojZvR8Mf8kyM7O+V8sQg==}
+  '@swc/core@1.15.43':
+    resolution: {integrity: sha512-1CuKjFkPxIgGdeHVuNbkxmBxkcbdc08u0aiI43pFq6yY1tTVKmXT9hFEooyyKs/sJ3xf1GPHyEwTtk9Xl8dvQw==}
     engines: {node: '>=10'}
     peerDependencies:
       '@swc/helpers': '>=0.5.17'
@@ -917,8 +917,8 @@ packages:
   '@swc/types@0.1.25':
     resolution: {integrity: sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==}
 
-  '@swc/types@0.1.26':
-    resolution: {integrity: sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==}
+  '@swc/types@0.1.27':
+    resolution: {integrity: sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==}
 
   '@taplo/cli@0.7.0':
     resolution: {integrity: sha512-Ck3zFhQhIhi02Hl6T4ZmJsXdnJE+wXcJz5f8klxd4keRYgenMnip3JDPMGDRLbnC/2iGd8P0sBIQqI3KxfVjBg==}
@@ -3015,67 +3015,67 @@ snapshots:
   '@swc/core-darwin-arm64@1.15.0':
     optional: true
 
-  '@swc/core-darwin-arm64@1.15.40':
+  '@swc/core-darwin-arm64@1.15.43':
     optional: true
 
   '@swc/core-darwin-x64@1.15.0':
     optional: true
 
-  '@swc/core-darwin-x64@1.15.40':
+  '@swc/core-darwin-x64@1.15.43':
     optional: true
 
   '@swc/core-linux-arm-gnueabihf@1.15.0':
     optional: true
 
-  '@swc/core-linux-arm-gnueabihf@1.15.40':
+  '@swc/core-linux-arm-gnueabihf@1.15.43':
     optional: true
 
   '@swc/core-linux-arm64-gnu@1.15.0':
     optional: true
 
-  '@swc/core-linux-arm64-gnu@1.15.40':
+  '@swc/core-linux-arm64-gnu@1.15.43':
     optional: true
 
   '@swc/core-linux-arm64-musl@1.15.0':
     optional: true
 
-  '@swc/core-linux-arm64-musl@1.15.40':
+  '@swc/core-linux-arm64-musl@1.15.43':
     optional: true
 
-  '@swc/core-linux-ppc64-gnu@1.15.40':
+  '@swc/core-linux-ppc64-gnu@1.15.43':
     optional: true
 
-  '@swc/core-linux-s390x-gnu@1.15.40':
+  '@swc/core-linux-s390x-gnu@1.15.43':
     optional: true
 
   '@swc/core-linux-x64-gnu@1.15.0':
     optional: true
 
-  '@swc/core-linux-x64-gnu@1.15.40':
+  '@swc/core-linux-x64-gnu@1.15.43':
     optional: true
 
   '@swc/core-linux-x64-musl@1.15.0':
     optional: true
 
-  '@swc/core-linux-x64-musl@1.15.40':
+  '@swc/core-linux-x64-musl@1.15.43':
     optional: true
 
   '@swc/core-win32-arm64-msvc@1.15.0':
     optional: true
 
-  '@swc/core-win32-arm64-msvc@1.15.40':
+  '@swc/core-win32-arm64-msvc@1.15.43':
     optional: true
 
   '@swc/core-win32-ia32-msvc@1.15.0':
     optional: true
 
-  '@swc/core-win32-ia32-msvc@1.15.40':
+  '@swc/core-win32-ia32-msvc@1.15.43':
     optional: true
 
   '@swc/core-win32-x64-msvc@1.15.0':
     optional: true
 
-  '@swc/core-win32-x64-msvc@1.15.40':
+  '@swc/core-win32-x64-msvc@1.15.43':
     optional: true
 
   '@swc/core@1.15.0':
@@ -3094,23 +3094,23 @@ snapshots:
       '@swc/core-win32-ia32-msvc': 1.15.0
       '@swc/core-win32-x64-msvc': 1.15.0
 
-  '@swc/core@1.15.40':
+  '@swc/core@1.15.43':
     dependencies:
       '@swc/counter': 0.1.3
-      '@swc/types': 0.1.26
+      '@swc/types': 0.1.27
     optionalDependencies:
-      '@swc/core-darwin-arm64': 1.15.40
-      '@swc/core-darwin-x64': 1.15.40
-      '@swc/core-linux-arm-gnueabihf': 1.15.40
-      '@swc/core-linux-arm64-gnu': 1.15.40
-      '@swc/core-linux-arm64-musl': 1.15.40
-      '@swc/core-linux-ppc64-gnu': 1.15.40
-      '@swc/core-linux-s390x-gnu': 1.15.40
-      '@swc/core-linux-x64-gnu': 1.15.40
-      '@swc/core-linux-x64-musl': 1.15.40
-      '@swc/core-win32-arm64-msvc': 1.15.40
-      '@swc/core-win32-ia32-msvc': 1.15.40
-      '@swc/core-win32-x64-msvc': 1.15.40
+      '@swc/core-darwin-arm64': 1.15.43
+      '@swc/core-darwin-x64': 1.15.43
+      '@swc/core-linux-arm-gnueabihf': 1.15.43
+      '@swc/core-linux-arm64-gnu': 1.15.43
+      '@swc/core-linux-arm64-musl': 1.15.43
+      '@swc/core-linux-ppc64-gnu': 1.15.43
+      '@swc/core-linux-s390x-gnu': 1.15.43
+      '@swc/core-linux-x64-gnu': 1.15.43
+      '@swc/core-linux-x64-musl': 1.15.43
+      '@swc/core-win32-arm64-msvc': 1.15.43
+      '@swc/core-win32-ia32-msvc': 1.15.43
+      '@swc/core-win32-x64-msvc': 1.15.43
 
   '@swc/counter@0.1.3': {}
 
@@ -3125,7 +3125,7 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
-  '@swc/types@0.1.26':
+  '@swc/types@0.1.27':
     dependencies:
       '@swc/counter': 0.1.3
 


### PR DESCRIPTION
React Compiler can leave generated Emotion calls with dummy spans, then @swc/plugin-emotion panics trying to attach comments/source maps at BytePos(0).

This keeps normal Emotion output untouched and only skips pure comments/source maps when there is no real source position to attach them to.

minimal reproduction of panic in rspack/swc: https://github.com/scttcper/swc-react-compiler-plugins