### PR TITLE
fix(graphql-codegen): preserve digit suffix pascal case

### DIFF
--- a/contrib/graphql-codegen-client-preset/src/lib.rs
+++ b/contrib/graphql-codegen-client-preset/src/lib.rs
@@ -35,6 +35,9 @@ fn to_pascal_case(s: &str) -> String {
         } else if chars[i - 1].is_lowercase() && chars[i].is_uppercase() {
             // lowercase → uppercase (e.g., someEG: e→E)
             true
+        } else if chars[i - 1].is_numeric() && chars[i].is_uppercase() {
+            // number → uppercase letter (e.g., Hero30Fragment: 0→F)
+            true
         } else if i + 1 < chars.len()
             && chars[i - 1].is_uppercase()
             && chars[i].is_uppercase()

--- a/contrib/graphql-codegen-client-preset/src/tests.rs
+++ b/contrib/graphql-codegen-client-preset/src/tests.rs
@@ -209,6 +209,25 @@ const SomeEGRockets = gql(`
 
 test!(
     Default::default(),
+    |_| visit_mut_pass(get_test_code_visitor()),
+    pascal_case_preserves_digit_suffix_boundaries,
+    r#"import gql from "gql-tag";
+
+const Hero30 = gql(`
+  fragment Hero30 on SomeType {
+    id
+  }
+`);
+
+const Foo1 = gql(`
+  query Foo1 {
+    id
+  }
+`);"#
+);
+
+test!(
+    Default::default(),
     |_| visit_mut_pass(get_test_code_visitor_upper_case_first()),
     upper_case_first_preserves_uppercase_sequences,
     r#"import gql from "gql-tag";
@@ -233,6 +252,26 @@ fn naming_convention_unknown_preserves_original_name() {
     assert_eq!(
         apply_naming_convention("SomeEGRocketsDocument", "lodash#camelCase"),
         "SomeEGRocketsDocument"
+    );
+}
+
+#[test]
+fn pascal_case_preserves_digit_suffixes() {
+    assert_eq!(
+        apply_naming_convention("Hero30FragmentDoc", "change-case-all#pascalCase"),
+        "Hero30FragmentDoc"
+    );
+    assert_eq!(
+        apply_naming_convention("Foo1Document", "change-case-all#pascalCase"),
+        "Foo1Document"
+    );
+    assert_eq!(
+        apply_naming_convention("Foo1barDocument", "change-case-all#pascalCase"),
+        "Foo1barDocument"
+    );
+    assert_eq!(
+        apply_naming_convention("SomeEGRocketsDocument", "change-case-all#pascalCase"),
+        "SomeEgRocketsDocument"
     );
 }
 

--- a/contrib/graphql-codegen-client-preset/tests/__swc_snapshots__/src/tests.rs/pascal_case_preserves_digit_suffix_boundaries.js
+++ b/contrib/graphql-codegen-client-preset/tests/__swc_snapshots__/src/tests.rs/pascal_case_preserves_digit_suffix_boundaries.js
@@ -1,0 +1,5 @@
+import { Hero30FragmentDoc } from "./src/gql/graphql";
+import { Foo1Document } from "./src/gql/graphql";
+import gql from "gql-tag";
+const Hero30 = Hero30FragmentDoc;
+const Foo1 = Foo1Document;


### PR DESCRIPTION
## Summary

Fixes #630.

This updates the GraphQL codegen client preset plugin's PascalCase normalization so a digit-to-letter transition is treated as a word boundary. That keeps generated import names aligned with `@graphql-codegen/client-preset` for names such as `Hero30FragmentDoc` and `Foo1Document`.

## Changes

- Add a `digit -> letter` boundary rule in `to_pascal_case`.
- Add direct naming-convention assertions for digit-suffixed fragment and operation names.
- Add an SWC transform snapshot covering both `fragment Hero30` and `query Foo1`.

## Validation

- `cargo test -p swc_plugin_graphql_codegen_client_preset --lib`