### PR TITLE
[codex] Add import-meta-env plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1634,7 +1634,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "modularize_imports"
-version = "8.0.0"
+version = "9.0.0"
 dependencies = [
  "convert_case",
  "handlebars",
@@ -2158,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "react_remove_properties"
-version = "8.0.0"
+version = "9.0.0"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -2228,7 +2228,7 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "remove_console"
-version = "8.0.0"
+version = "9.0.0"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -2655,7 +2655,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "styled_components"
-version = "8.0.0"
+version = "9.0.0"
 dependencies = [
  "Inflector",
  "once_cell",
@@ -2677,7 +2677,7 @@ dependencies = [
 
 [[package]]
 name = "styled_jsx"
-version = "8.0.0"
+version = "9.0.0"
 dependencies = [
  "anyhow",
  "lightningcss",
@@ -2783,7 +2783,7 @@ dependencies = [
 
 [[package]]
 name = "swc_confidential"
-version = "8.0.0"
+version = "9.0.0"
 dependencies = [
  "cipher 0.4.4",
  "hex",
@@ -3286,7 +3286,7 @@ dependencies = [
 
 [[package]]
 name = "swc_emotion"
-version = "8.0.0"
+version = "9.0.0"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
@@ -3339,7 +3339,7 @@ dependencies = [
 
 [[package]]
 name = "swc_experimental_babel"
-version = "8.0.0"
+version = "9.0.0"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -3359,7 +3359,7 @@ dependencies = [
 
 [[package]]
 name = "swc_feature_flags"
-version = "8.0.0"
+version = "9.0.0"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -3375,7 +3375,7 @@ dependencies = [
 
 [[package]]
 name = "swc_formatjs_transform"
-version = "31.0.0"
+version = "32.0.0"
 dependencies = [
  "base64ct",
  "digest 0.10.7",
@@ -3396,7 +3396,7 @@ dependencies = [
 
 [[package]]
 name = "swc_icu_messageformat_parser"
-version = "27.0.0"
+version = "28.0.0"
 dependencies = [
  "langtag",
  "once_cell",
@@ -3422,7 +3422,7 @@ dependencies = [
 
 [[package]]
 name = "swc_magic"
-version = "8.0.0"
+version = "9.0.0"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -3439,7 +3439,7 @@ dependencies = [
 
 [[package]]
 name = "swc_mut_cjs_exports"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "rustc-hash",
  "swc_core",
@@ -3503,6 +3503,13 @@ dependencies = [
  "pathdiff",
  "serde",
  "serde_json",
+ "swc_core",
+]
+
+[[package]]
+name = "swc_plugin_import_meta_env"
+version = "0.1.0"
+dependencies = [
  "swc_core",
 ]
 
@@ -3722,7 +3729,7 @@ dependencies = [
 
 [[package]]
 name = "swc_prefresh"
-version = "8.0.0"
+version = "9.0.0"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -3738,7 +3745,7 @@ dependencies = [
 
 [[package]]
 name = "swc_relay"
-version = "8.0.0"
+version = "9.0.0"
 dependencies = [
  "once_cell",
  "regex",
@@ -3756,7 +3763,7 @@ dependencies = [
 
 [[package]]
 name = "swc_sdk"
-version = "8.0.0"
+version = "9.0.0"
 dependencies = [
  "default-from-serde",
  "rustc-hash",

--- a/packages/import-meta-env/.npmignore
+++ b/packages/import-meta-env/.npmignore
@@ -1,0 +1,2 @@
+__tests__/
+Cargo.toml

--- a/packages/import-meta-env/CHANGELOG.md
+++ b/packages/import-meta-env/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @swc/plugin-import-meta-env
+
+## 0.1.0
+
+### Minor Changes
+
+- Initial release: transform `import.meta.env` expressions to `process.env`.

--- a/packages/import-meta-env/Cargo.toml
+++ b/packages/import-meta-env/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+description = "SWC plugin for transforming import.meta.env to process.env"
+name        = "swc_plugin_import_meta_env"
+version     = "0.1.0"
+
+authors      = { workspace = true }
+edition      = { workspace = true }
+homepage     = { workspace = true }
+license      = { workspace = true }
+publish      = false
+repository   = { workspace = true }
+rust-version = { workspace = true }
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+swc_core = { workspace = true, features = ["ecma_plugin_transform"] }

--- a/packages/import-meta-env/README.md
+++ b/packages/import-meta-env/README.md
@@ -1,0 +1,47 @@
+# @swc/plugin-import-meta-env
+
+`@swc/plugin-import-meta-env` transforms `import.meta.env` expressions to `process.env`.
+
+This is useful when code written for Vite-style `import.meta.env` needs to run in an environment where values are already exposed through `process.env`, such as Jest or Node-based test tooling.
+
+## Usage
+
+`.swcrc`:
+
+```json
+{
+  "jsc": {
+    "experimental": {
+      "plugins": [["@swc/plugin-import-meta-env", {}]]
+    }
+  }
+}
+```
+
+### Input
+
+```js
+const mode = import.meta.env.MODE;
+const value = import.meta.env["VALUE"];
+```
+
+### Output
+
+```js
+const mode = process.env.MODE;
+const value = process.env["VALUE"];
+```
+
+## Notes
+
+This plugin only rewrites the expression shape. It does not load `.env` files, inline values, or emulate Vite environment variable filtering.
+
+This package is based on the Apache-2.0 licensed [`swc-plugin-import-meta-env`](https://github.com/Codex-/swc-plugin-import-meta-env) implementation.
+
+# @swc/plugin-import-meta-env
+
+## 0.1.0
+
+### Minor Changes
+
+- Initial release: transform `import.meta.env` expressions to `process.env`.

--- a/packages/import-meta-env/README.tmpl.md
+++ b/packages/import-meta-env/README.tmpl.md
@@ -1,0 +1,41 @@
+# @swc/plugin-import-meta-env
+
+`@swc/plugin-import-meta-env` transforms `import.meta.env` expressions to `process.env`.
+
+This is useful when code written for Vite-style `import.meta.env` needs to run in an environment where values are already exposed through `process.env`, such as Jest or Node-based test tooling.
+
+## Usage
+
+`.swcrc`:
+
+```json
+{
+  "jsc": {
+    "experimental": {
+      "plugins": [["@swc/plugin-import-meta-env", {}]]
+    }
+  }
+}
+```
+
+### Input
+
+```js
+const mode = import.meta.env.MODE;
+const value = import.meta.env["VALUE"];
+```
+
+### Output
+
+```js
+const mode = process.env.MODE;
+const value = process.env["VALUE"];
+```
+
+## Notes
+
+This plugin only rewrites the expression shape. It does not load `.env` files, inline values, or emulate Vite environment variable filtering.
+
+This package is based on the Apache-2.0 licensed [`swc-plugin-import-meta-env`](https://github.com/Codex-/swc-plugin-import-meta-env) implementation.
+
+${CHANGELOG}

--- a/packages/import-meta-env/__tests__/wasm.test.ts
+++ b/packages/import-meta-env/__tests__/wasm.test.ts
@@ -1,0 +1,77 @@
+import { expect, test } from "vitest";
+import { transform } from "@swc/core";
+import path from "node:path";
+import url from "node:url";
+
+const pluginName = "swc_plugin_import_meta_env.wasm";
+
+const transformCode = async (
+  code: string,
+  parser:
+    | { syntax: "ecmascript"; jsx?: boolean }
+    | { syntax: "typescript"; tsx?: boolean } = {
+    syntax: "ecmascript",
+  },
+) => {
+  return transform(code, {
+    jsc: {
+      parser,
+      target: "es2018",
+      experimental: {
+        plugins: [
+          [
+            path.join(
+              path.dirname(url.fileURLToPath(import.meta.url)),
+              "..",
+              pluginName,
+            ),
+            {},
+          ],
+        ],
+      },
+    },
+    filename:
+      parser.syntax === "typescript" && parser.tsx ? "test.tsx" : "test.js",
+  });
+};
+
+test("transforms import.meta.env expressions to process.env", async () => {
+  const { code } = await transformCode(`
+const env = import.meta.env;
+const mode = import.meta.env.MODE;
+const prop = import.meta.env["PROP"];
+`);
+
+  expect(code).toContain("const env = process.env;");
+  expect(code).toContain("const mode = process.env.MODE;");
+  expect(code).toContain('const prop = process.env["PROP"];');
+  expect(code).not.toContain("import.meta.env");
+});
+
+test("leaves other import.meta expressions unchanged", async () => {
+  const { code } = await transformCode(`
+const meta = import.meta;
+const glob = import.meta.glob("./*.ts");
+const computed = import.meta["env"];
+`);
+
+  expect(code).toContain("const meta = import.meta;");
+  expect(code).toContain('const glob = import.meta.glob("./*.ts");');
+  expect(code).toContain('const computed = import.meta["env"];');
+  expect(code).not.toContain("process.env");
+});
+
+test("works with TypeScript and TSX input", async () => {
+  const { code } = await transformCode(
+    `
+const Component = () => <span>{import.meta.env.MODE as string}</span>;
+`,
+    {
+      syntax: "typescript",
+      tsx: true,
+    },
+  );
+
+  expect(code).toContain("process.env.MODE");
+  expect(code).not.toContain("import.meta.env");
+});

--- a/packages/import-meta-env/package.json
+++ b/packages/import-meta-env/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@swc/plugin-import-meta-env",
+  "version": "0.1.0",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "description": "SWC plugin for transforming import.meta.env to process.env",
+  "main": "swc_plugin_import_meta_env.wasm",
+  "scripts": {
+    "prepack": "pnpm run build",
+    "build": "RUSTFLAGS='--cfg swc_ast_unknown' cargo build --release -p swc_plugin_import_meta_env --target wasm32-wasip1 && cp ../../target/wasm32-wasip1/release/swc_plugin_import_meta_env.wasm .",
+    "build:debug": "RUSTFLAGS='--cfg swc_ast_unknown' cargo build -p swc_plugin_import_meta_env --target wasm32-wasip1 && cp ../../target/wasm32-wasip1/debug/swc_plugin_import_meta_env.wasm .",
+    "test": "pnpm run build:debug && vitest run --testTimeout=0"
+  },
+  "homepage": "https://swc.rs",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/swc-project/plugins.git",
+    "directory": "packages/import-meta-env"
+  },
+  "bugs": {
+    "url": "https://github.com/swc-project/plugins/issues"
+  },
+  "author": "강동윤 <kdy1997.dev@gmail.com>",
+  "keywords": [
+    "swc",
+    "swc-plugin",
+    "import.meta.env",
+    "process.env"
+  ],
+  "license": "Apache-2.0",
+  "preferUnplugged": true,
+  "dependencies": {
+    "@swc/counter": "^0.1.3"
+  }
+}

--- a/packages/import-meta-env/src/lib.rs
+++ b/packages/import-meta-env/src/lib.rs
@@ -1,0 +1,47 @@
+#![allow(clippy::not_unsafe_ptr_arg_deref)]
+
+use swc_core::{
+    common::DUMMY_SP,
+    ecma::{
+        ast::{Expr, Ident, MemberExpr, MetaPropKind, Program},
+        visit::{noop_visit_mut_type, VisitMut, VisitMutWith},
+    },
+    plugin::{plugin_transform, proxies::TransformPluginProgramMetadata},
+};
+
+pub struct ImportMetaEnv;
+
+impl VisitMut for ImportMetaEnv {
+    noop_visit_mut_type!();
+
+    fn visit_mut_expr(&mut self, expr: &mut Expr) {
+        expr.visit_mut_children_with(self);
+
+        if let Expr::Member(member) = expr {
+            if is_import_meta_env(member) {
+                member.obj = Box::new(Ident::new_no_ctxt("process".into(), DUMMY_SP).into());
+            }
+        }
+    }
+}
+
+fn is_import_meta_env(member: &MemberExpr) -> bool {
+    let Some(obj) = member.obj.as_meta_prop() else {
+        return false;
+    };
+
+    let Some(prop) = member.prop.as_ident() else {
+        return false;
+    };
+
+    obj.kind == MetaPropKind::ImportMeta && prop.sym == "env"
+}
+
+#[plugin_transform]
+fn swc_plugin_import_meta_env(
+    mut program: Program,
+    _metadata: TransformPluginProgramMetadata,
+) -> Program {
+    program.visit_mut_with(&mut ImportMetaEnv);
+    program
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,12 @@ importers:
         specifier: ^0.1.3
         version: 0.1.3
 
+  packages/import-meta-env:
+    dependencies:
+      '@swc/counter':
+        specifier: ^0.1.3
+        version: 0.1.3
+
   packages/jest:
     dependencies:
       '@swc/counter':


### PR DESCRIPTION
## Summary

- Add `@swc/plugin-import-meta-env` as a new SWC wasm plugin package.
- Transform `import.meta.env` member expressions to `process.env` while leaving other `import.meta` usage untouched.
- Add package metadata, docs, changelog, and Vitest coverage for the wasm plugin.

## Why

Fixes #612 by bringing the Apache-2.0 `swc-plugin-import-meta-env` behavior into this monorepo under the scoped `@swc/plugin-import-meta-env` package.

## Validation

- `RUSTFLAGS='--cfg swc_ast_unknown' cargo check -p swc_plugin_import_meta_env`
- `cargo test -p swc_plugin_import_meta_env --color always`
- `pnpm -F @swc/plugin-import-meta-env test` using the repo's Corepack pnpm version