### PR TITLE
Add import-meta-env contrib plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3506,6 +3506,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "swc_plugin_import_meta_env"
+version = "1.15.41"
+dependencies = [
+ "swc_core",
+]
+
+[[package]]
 name = "swc_plugin_jest"
 version = "0.31.4"
 dependencies = [

--- a/contrib/import-meta-env/.gitignore
+++ b/contrib/import-meta-env/.gitignore
@@ -1,0 +1,2 @@
+*.wasm
+target/

--- a/contrib/import-meta-env/.npmignore
+++ b/contrib/import-meta-env/.npmignore
@@ -1,0 +1,6 @@
+__tests__/
+tests/
+src/
+Cargo.toml
+Cargo.lock
+*.rs

--- a/contrib/import-meta-env/CHANGELOG.md
+++ b/contrib/import-meta-env/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @swc-contrib/plugin-import-meta-env
+
+## 1.15.41
+
+### Minor Changes
+
+- Add `@swc-contrib/plugin-import-meta-env`, based on `swc-plugin-import-meta-env`.

--- a/contrib/import-meta-env/Cargo.toml
+++ b/contrib/import-meta-env/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+authors      = ["Alex Miller <codex.nz@gmail.com>"]
+description  = "SWC plugin for handling the transformation of import.meta.env"
+edition      = "2021"
+license      = "Apache-2.0"
+name         = "swc_plugin_import_meta_env"
+publish      = false
+readme       = "README.md"
+rust-version = "1.70"
+version      = "1.15.41"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+swc_core = { workspace = true, features = [
+  "common",
+  "ecma_ast",
+  "ecma_parser",
+  "ecma_plugin_transform",
+  "ecma_visit",
+  "testing",
+  "testing_transform",
+] }

--- a/contrib/import-meta-env/README.md
+++ b/contrib/import-meta-env/README.md
@@ -1,0 +1,35 @@
+# `@swc-contrib/plugin-import-meta-env`
+
+Simple SWC plugin to transform `import.meta.env` to `process.env`.
+
+This package is based on [`swc-plugin-import-meta-env`](https://github.com/Codex-/swc-plugin-import-meta-env) and is maintained under the SWC contrib plugin workspace.
+
+## Installation
+
+```bash
+npm i -D @swc-contrib/plugin-import-meta-env
+```
+
+## Usage
+
+Add the plugin to the `jsc.experimental.plugins` field of your `.swcrc`.
+
+```json
+{
+  "jsc": {
+    "experimental": {
+      "plugins": [["@swc-contrib/plugin-import-meta-env", {}]]
+    }
+  }
+}
+```
+
+The plugin only rewrites the `import.meta.env` expression shape. It does not load or expand environment files, so populate `process.env` through your test setup, runtime, or another tool such as `dotenv`.
+
+# @swc-contrib/plugin-import-meta-env
+
+## 1.15.41
+
+### Minor Changes
+
+- Add `@swc-contrib/plugin-import-meta-env`, based on `swc-plugin-import-meta-env`.

--- a/contrib/import-meta-env/package.json
+++ b/contrib/import-meta-env/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@swc-contrib/plugin-import-meta-env",
+  "version": "1.15.41",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "description": "SWC plugin for handling the transformation of import.meta.env",
+  "author": "Alex Miller <codex.nz@gmail.com>",
+  "license": "Apache-2.0",
+  "keywords": [
+    "swc-plugin",
+    "import.meta.env"
+  ],
+  "main": "swc_plugin_import_meta_env.wasm",
+  "scripts": {
+    "prepack": "pnpm run build",
+    "build": "RUSTFLAGS='--cfg swc_ast_unknown' cargo build --release -p swc_plugin_import_meta_env --target wasm32-wasip1 && cp ../../target/wasm32-wasip1/release/swc_plugin_import_meta_env.wasm .",
+    "build:debug": "RUSTFLAGS='--cfg swc_ast_unknown' cargo build -p swc_plugin_import_meta_env --target wasm32-wasip1 && cp ../../target/wasm32-wasip1/debug/swc_plugin_import_meta_env.wasm .",
+    "test": "cargo test -p swc_plugin_import_meta_env --color always"
+  },
+  "homepage": "https://github.com/swc-project/plugins/tree/main/contrib/import-meta-env",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/swc-project/plugins.git",
+    "directory": "contrib/import-meta-env"
+  },
+  "bugs": {
+    "url": "https://github.com/swc-project/plugins/issues"
+  },
+  "files": [
+    "swc_plugin_import_meta_env.wasm"
+  ],
+  "preferUnplugged": true,
+  "peerDependencies": {
+    "@swc/core": ">=1.15.4"
+  }
+}

--- a/contrib/import-meta-env/src/lib.rs
+++ b/contrib/import-meta-env/src/lib.rs
@@ -1,0 +1,95 @@
+#![allow(clippy::not_unsafe_ptr_arg_deref)]
+
+use swc_core::{
+    common::DUMMY_SP,
+    ecma::{
+        ast::{Expr, Ident, MemberExpr, MetaPropKind, Program},
+        visit::{noop_visit_mut_type, visit_mut_pass, VisitMut, VisitMutWith},
+    },
+    plugin::{plugin_transform, proxies::TransformPluginProgramMetadata},
+};
+
+pub struct TransformVisitor;
+
+impl VisitMut for TransformVisitor {
+    noop_visit_mut_type!();
+
+    fn visit_mut_expr(&mut self, n: &mut Expr) {
+        n.visit_mut_children_with(self);
+
+        if let Expr::Member(member) = n {
+            if is_import_meta_env(member) {
+                member.obj = Box::new(Ident::new_no_ctxt("process".into(), DUMMY_SP).into());
+            }
+        }
+    }
+}
+
+fn is_import_meta_env(n: &MemberExpr) -> bool {
+    let Some(obj) = n.obj.as_meta_prop() else {
+        return false;
+    };
+    let Some(prop) = n.prop.as_ident() else {
+        return false;
+    };
+
+    obj.kind == MetaPropKind::ImportMeta && prop.sym == "env"
+}
+
+#[plugin_transform]
+pub fn process_transform(program: Program, _metadata: TransformPluginProgramMetadata) -> Program {
+    program.apply(&mut visit_mut_pass(TransformVisitor))
+}
+
+#[cfg(test)]
+mod tests {
+    use swc_core::ecma::{
+        parser::{EsSyntax, Syntax},
+        transforms::testing::test,
+        visit::visit_mut_pass,
+    };
+
+    use super::*;
+
+    fn syntax() -> Syntax {
+        Syntax::Es(EsSyntax {
+            import_attributes: true,
+            ..Default::default()
+        })
+    }
+
+    test!(
+        syntax(),
+        |_| visit_mut_pass(TransformVisitor),
+        transform_import_meta_env,
+        r#"import.meta.env"#
+    );
+
+    test!(
+        syntax(),
+        |_| visit_mut_pass(TransformVisitor),
+        transform_import_meta_env_prop,
+        r#"import.meta.env.MODE"#
+    );
+
+    test!(
+        syntax(),
+        |_| visit_mut_pass(TransformVisitor),
+        transform_import_meta_env_key,
+        r#"import.meta.env["PROP"]"#
+    );
+
+    test!(
+        syntax(),
+        |_| visit_mut_pass(TransformVisitor),
+        no_transform_import_meta,
+        r#"import.meta"#
+    );
+
+    test!(
+        syntax(),
+        |_| visit_mut_pass(TransformVisitor),
+        no_transform_import_meta_glob,
+        r#"import.meta.glob"#
+    );
+}

--- a/contrib/import-meta-env/tests/__swc_snapshots__/src/lib.rs/no_transform_import_meta.js
+++ b/contrib/import-meta-env/tests/__swc_snapshots__/src/lib.rs/no_transform_import_meta.js
@@ -1,0 +1,1 @@
+import.meta;

--- a/contrib/import-meta-env/tests/__swc_snapshots__/src/lib.rs/no_transform_import_meta_glob.js
+++ b/contrib/import-meta-env/tests/__swc_snapshots__/src/lib.rs/no_transform_import_meta_glob.js
@@ -1,0 +1,1 @@
+import.meta.glob;

--- a/contrib/import-meta-env/tests/__swc_snapshots__/src/lib.rs/transform_import_meta_env.js
+++ b/contrib/import-meta-env/tests/__swc_snapshots__/src/lib.rs/transform_import_meta_env.js
@@ -1,0 +1,1 @@
+process.env;

--- a/contrib/import-meta-env/tests/__swc_snapshots__/src/lib.rs/transform_import_meta_env_key.js
+++ b/contrib/import-meta-env/tests/__swc_snapshots__/src/lib.rs/transform_import_meta_env_key.js
@@ -1,0 +1,1 @@
+process.env["PROP"];

--- a/contrib/import-meta-env/tests/__swc_snapshots__/src/lib.rs/transform_import_meta_env_prop.js
+++ b/contrib/import-meta-env/tests/__swc_snapshots__/src/lib.rs/transform_import_meta_env_prop.js
@@ -1,0 +1,1 @@
+process.env.MODE;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,12 @@ importers:
 
   contrib/graphql-codegen-client-preset: {}
 
+  contrib/import-meta-env:
+    dependencies:
+      '@swc/core':
+        specifier: '>=1.15.4'
+        version: 1.15.43
+
   contrib/mut-cjs-exports:
     dependencies:
       '@swc/core':


### PR DESCRIPTION
## Summary

- Add `@swc-contrib/plugin-import-meta-env` under `contrib/import-meta-env`
- Port the `import.meta.env` to `process.env` transform from `swc-plugin-import-meta-env`
- Add Rust snapshot tests, package metadata, README, changelog, and workspace lockfile entries

Closes #612.

## Validation

- `cargo fmt -p swc_plugin_import_meta_env --check`
- `corepack pnpm exec taplo format --check contrib/import-meta-env/Cargo.toml`
- `cargo test -p swc_plugin_import_meta_env --color always`
- `RUSTFLAGS='--cfg swc_ast_unknown' cargo check -p swc_plugin_import_meta_env`
- `corepack pnpm -F @swc-contrib/plugin-import-meta-env run build`
- `corepack pnpm exec lint-staged`