### PR TITLE
fix(emotion): preserve dynamic css prop arrays

### DIFF
--- a/.changeset/fix-emotion-dynamic-css-arrays.md
+++ b/.changeset/fix-emotion-dynamic-css-arrays.md
@@ -1,0 +1,5 @@
+---
+"@swc/plugin-emotion": patch
+---
+
+Keep dynamic Emotion JSX css prop arrays unwrapped so theme callbacks are evaluated by Emotion's JSX runtime.

--- a/packages/emotion/__tests__/wasm.test.ts
+++ b/packages/emotion/__tests__/wasm.test.ts
@@ -156,3 +156,49 @@ test("Should transform css prop output from React Compiler", async () => {
 
   expect(output.code).toContain('css("width:120px;", "")');
 });
+
+test("Should not wrap dynamic css prop arrays", async () => {
+  const output = await transform(
+    `
+      import { css } from "@emotion/react";
+      import { forwardRef } from "react";
+
+      const styles = {
+        row: (theme) => css({ display: "grid", gap: theme.spacing.sm }),
+      };
+
+      export const Row = forwardRef((props, ref) => (
+        <div ref={ref} css={[styles.row, {}]} {...props} />
+      ));
+    `,
+    {
+      jsc: {
+        parser: {
+          syntax: "ecmascript",
+          jsx: true,
+        },
+        transform: {
+          react: {
+            runtime: "automatic",
+            importSource: "@emotion/react",
+          },
+        },
+        experimental: {
+          plugins: [
+            [
+              pluginPath,
+              {
+                autoLabel: "never",
+                sourceMap: false,
+              },
+            ],
+          ],
+        },
+      },
+    } satisfies Options,
+  );
+
+  expect(output.code).toContain("css: [");
+  expect(output.code).toContain("styles.row");
+  expect(output.code).not.toContain("css([");
+});

--- a/packages/emotion/transform/src/lib.rs
+++ b/packages/emotion/transform/src/lib.rs
@@ -512,10 +512,13 @@ impl<'a, C: Comments> EmotionTransformer<'a, C> {
                     continue;
                 }
 
-                // Only transform object and array expressions; skip calls, template
-                // literals, identifiers, etc. which are handled elsewhere
+                // Only transform object and fully static array expressions; skip
+                // calls, template literals, identifiers, dynamic arrays, etc.
+                // which are handled elsewhere or by Emotion's JSX runtime.
                 match expr.as_ref() {
-                    Expr::Object(_) | Expr::Array(_) => {}
+                    Expr::Object(_) => {}
+                    Expr::Array(array) if can_rewrite_css_prop_array(array) => {}
+                    Expr::Array(_) => break,
                     _ => continue,
                 }
 
@@ -1087,6 +1090,38 @@ fn match_runtime_export(item: &ExportItem, prop: &MemberProp) -> Option<ExprKind
         }
     }
     None
+}
+
+fn can_rewrite_css_prop_array(array: &ArrayLit) -> bool {
+    array.elems.iter().all(|elem| match elem {
+        Some(ExprOrSpread { spread: None, expr }) => can_rewrite_static_css_prop_expr(expr),
+        _ => false,
+    })
+}
+
+fn can_rewrite_static_css_prop_expr(expr: &Expr) -> bool {
+    match expr {
+        Expr::Lit(_) => true,
+        Expr::Tpl(tpl) => tpl.exprs.is_empty(),
+        Expr::Object(object) => can_rewrite_static_css_prop_object(object),
+        Expr::Array(array) => can_rewrite_css_prop_array(array),
+        Expr::Paren(paren) => can_rewrite_static_css_prop_expr(&paren.expr),
+        _ => false,
+    }
+}
+
+fn can_rewrite_static_css_prop_object(object: &ObjectLit) -> bool {
+    object.props.iter().all(|prop| match prop {
+        PropOrSpread::Prop(prop) => match &**prop {
+            Prop::KeyValue(KeyValueProp { key, value }) => {
+                !matches!(key, PropName::Computed(_)) && can_rewrite_static_css_prop_expr(value)
+            }
+            _ => false,
+        },
+        PropOrSpread::Spread(_) => false,
+        #[cfg(swc_ast_unknown)]
+        _ => false,
+    })
 }
 
 #[inline]

--- a/packages/emotion/transform/tests/fixture/issues/635/input.tsx
+++ b/packages/emotion/transform/tests/fixture/issues/635/input.tsx
@@ -1,0 +1,14 @@
+import { css } from "@emotion/react";
+import { forwardRef } from "react";
+
+const styles = {
+  row: (theme) => css({ display: "grid", gap: theme.spacing.sm }),
+};
+
+export const RowWithSpread = forwardRef((props, ref) => (
+  <div ref={ref} css={[styles.row, {}]} {...props} />
+));
+
+export function RowWithoutSpread() {
+  return <div css={[styles.row, {}]} />;
+}

--- a/packages/emotion/transform/tests/fixture/issues/635/output.ts
+++ b/packages/emotion/transform/tests/fixture/issues/635/output.ts
@@ -1,0 +1,25 @@
+import { jsx as _jsx } from "react/jsx-runtime";
+import { css } from "@emotion/react";
+import { forwardRef } from "react";
+const styles = {
+    row: (theme)=>/*#__PURE__*/ css({
+            display: "grid",
+            gap: theme.spacing.sm
+        }, "label:row", "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiaW5wdXQudHMiLCJzb3VyY2VzIjpbImlucHV0LnRzIl0sInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gXCJAZW1vdGlvbi9yZWFjdFwiO1xuaW1wb3J0IHsgZm9yd2FyZFJlZiB9IGZyb20gXCJyZWFjdFwiO1xuXG5jb25zdCBzdHlsZXMgPSB7XG4gIHJvdzogKHRoZW1lKSA9PiBjc3MoeyBkaXNwbGF5OiBcImdyaWRcIiwgZ2FwOiB0aGVtZS5zcGFjaW5nLnNtIH0pLFxufTtcblxuZXhwb3J0IGNvbnN0IFJvd1dpdGhTcHJlYWQgPSBmb3J3YXJkUmVmKChwcm9wcywgcmVmKSA9PiAoXG4gIDxkaXYgcmVmPXtyZWZ9IGNzcz17W3N0eWxlcy5yb3csIHt9XX0gey4uLnByb3BzfSAvPlxuKSk7XG5cbmV4cG9ydCBmdW5jdGlvbiBSb3dXaXRob3V0U3ByZWFkKCkge1xuICByZXR1cm4gPGRpdiBjc3M9e1tzdHlsZXMucm93LCB7fV19IC8+O1xufVxuIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUlrQiJ9 */")
+};
+export const RowWithSpread = forwardRef((props, ref)=>/*#__PURE__*/ _jsx("div", {
+        ref: ref,
+        css: [
+            styles.row,
+            {}
+        ],
+        ...props
+    }));
+export function RowWithoutSpread() {
+    return /*#__PURE__*/ _jsx("div", {
+        css: [
+            styles.row,
+            {}
+        ]
+    });
+}


### PR DESCRIPTION
## Summary

Fixes #635.

This keeps dynamic JSX `css` prop arrays, such as `css={[styles.row, {}]}`, as raw arrays instead of rewriting them to `css([...])`. Emotion needs the raw array to reach the JSX runtime so theme callbacks can be evaluated with the active theme.

## Changes

- Restrict the JSX `css` prop rewrite to object expressions and fully static array expressions.
- Leave dynamic arrays unwrapped when they contain identifiers, member expressions, calls, spreads, or other runtime expressions.
- Add a regression fixture for the reported spread case and the same dynamic array without prop spread.
- Add a WASM regression test to ensure dynamic arrays do not produce `css([`.
- Add a patch changeset for `@swc/plugin-emotion`.

## Validation

- `cargo test -p swc_emotion`
- `cargo test -p swc_emotion --test fixture -- --include-ignored`
- `RUSTFLAGS='--cfg swc_ast_unknown' cargo build -p swc_plugin_emotion --target wasm32-wasip1`
- `node_modules/.bin/vitest run packages/emotion/__tests__/wasm.test.ts --testTimeout=0`

Note: `pnpm -F @swc/plugin-emotion test` was blocked in this environment before running by pnpm build-script approval (`ERR_PNPM_IGNORED_BUILDS`), so I ran the package script's build and vitest steps directly.